### PR TITLE
Support split frontend/backend auth configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,14 @@ REFRESH_TOKEN_LIFETIME_HOURS=720
 # 登录成功后前端回调地址
 FRONTEND_CALLBACK_URL=http://localhost:5173/auth/callback
 
+# 对外可访问的后端基础地址，用于拼接登录入口和 OIDC 回调地址
+API_BASE_URL=http://localhost:8080
+
 
 # ---- 跨域 ----
+# 服务监听端口，默认 8080
+PORT=8080
+
 # 多个来源用英文逗号分隔；本地开发默认允许 http://localhost:5173
 CORS_ALLOWED_ORIGINS=http://localhost:5173
 

--- a/packages/server/cmd/server/main.go
+++ b/packages/server/cmd/server/main.go
@@ -115,9 +115,14 @@ func main() {
 		return c.SendString("Hello from CyimeWrite Server!")
 	})
 
-	log.Println("Starting server on port 8080...")
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	log.Printf("Starting server on port %s...", port)
 	// Start server
-	if err := app.Listen(":8080"); err != nil {
+	if err := app.Listen(":" + port); err != nil {
 		log.Fatalf("Failed to start server: %v", err)
 	}
 }

--- a/packages/server/go.mod
+++ b/packages/server/go.mod
@@ -1,6 +1,6 @@
 module g.co1d.in/Coldin04/CyimeWrite/server
 
-go 1.25.6
+go 1.25
 
 require (
 	github.com/google/uuid v1.6.0

--- a/packages/server/internal/auth/handler.go
+++ b/packages/server/internal/auth/handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -519,12 +520,13 @@ func fetchGitHubPrimaryEmail(ctx context.Context, oauth2Config *oauth2.Config, t
 	client := oauth2Config.Client(ctx, token)
 	resp, err := client.Get("https://api.github.com/user/emails")
 	if err != nil {
-		return "", fmt.Errorf("无法获取 GitHub 邮箱信息")
+		return "", fmt.Errorf("无法获取 GitHub 邮箱信息: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("无法获取 GitHub 邮箱信息")
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", fmt.Errorf("无法获取 GitHub 邮箱信息: status %d, body: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var emails []struct {
@@ -533,7 +535,7 @@ func fetchGitHubPrimaryEmail(ctx context.Context, oauth2Config *oauth2.Config, t
 		Verified bool   `json:"verified"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&emails); err != nil {
-		return "", fmt.Errorf("无法解析 GitHub 邮箱信息")
+		return "", fmt.Errorf("无法解析 GitHub 邮箱信息: %w", err)
 	}
 
 	for _, item := range emails {

--- a/packages/server/internal/auth/handler.go
+++ b/packages/server/internal/auth/handler.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -66,6 +68,15 @@ type SessionResponseDTO struct {
 	Current     bool      `json:"current"`
 }
 
+func getAPIBaseURL() string {
+	baseURL := strings.TrimSpace(os.Getenv("API_BASE_URL"))
+	if baseURL == "" {
+		baseURL = "http://localhost:8080"
+	}
+
+	return strings.TrimRight(baseURL, "/")
+}
+
 // GetAuthConfig is the handler for GET /api/v1/auth/config
 func GetAuthConfig(c *fiber.Ctx) error {
 	var dbProviders []models.AuthProvider
@@ -82,7 +93,7 @@ func GetAuthConfig(c *fiber.Ctx) error {
 		responseProviders = append(responseProviders, ProviderInfo{
 			Name:   p.Name,
 			Icon:   iconURL,
-			SSOUrl: "/api/v1/auth/login/" + p.Name,
+			SSOUrl: getAPIBaseURL() + "/api/v1/auth/login/" + p.Name,
 		})
 	}
 
@@ -109,7 +120,7 @@ func AuthLogin(c *fiber.Ctx) error {
 	oauth2Config := oauth2.Config{
 		ClientID:     dbProvider.ClientID,
 		ClientSecret: dbProvider.ClientSecretEncrypted,
-		RedirectURL:  fmt.Sprintf("http://localhost:8080/api/v1/auth/callback/%s", providerName),
+		RedirectURL:  fmt.Sprintf("%s/api/v1/auth/callback/%s", getAPIBaseURL(), providerName),
 		Endpoint:     endpoint,
 		Scopes:       strings.Split(dbProvider.Scopes, " "),
 	}
@@ -145,7 +156,7 @@ func AuthCallback(c *fiber.Ctx) error {
 	oauth2Config := oauth2.Config{
 		ClientID:     dbProvider.ClientID,
 		ClientSecret: dbProvider.ClientSecretEncrypted,
-		RedirectURL:  fmt.Sprintf("http://localhost:8080/api/v1/auth/callback/%s", providerName),
+		RedirectURL:  fmt.Sprintf("%s/api/v1/auth/callback/%s", getAPIBaseURL(), providerName),
 		Endpoint:     endpoint,
 		Scopes:       strings.Split(dbProvider.Scopes, " "),
 	}
@@ -331,9 +342,9 @@ func findOrCreateUser(tx *gorm.DB, providerName string, userProfile *UserProfile
 
 	// 2. Identity not found, so we create a new user and a new identity.
 	newUser := models.User{
-		Email:       &userProfile.Email,
-		DisplayName: &userProfile.Name,
-		AvatarURL:   &userProfile.Picture,
+		Email:       optionalStringPtr(userProfile.Email),
+		DisplayName: optionalStringPtr(userProfile.Name),
+		AvatarURL:   optionalStringPtr(userProfile.Picture),
 	}
 	if err := tx.Create(&newUser).Error; err != nil {
 		return nil, fmt.Errorf("创建新用户失败: %w", err)
@@ -479,7 +490,20 @@ func getUserProfile(ctx context.Context, provider *models.AuthProvider, oauth2Co
 			if userName == "" {
 				userName = ghUser.Login
 			}
-			userProfile = UserProfile{Subject: fmt.Sprintf("%d", ghUser.ID), Email: ghUser.Email, Name: userName, Picture: ghUser.Avatar}
+			userEmail := strings.TrimSpace(ghUser.Email)
+			if userEmail == "" {
+				fallbackEmail, err := fetchGitHubPrimaryEmail(ctx, oauth2Config, token)
+				if err != nil {
+					return nil, err
+				}
+				userEmail = fallbackEmail
+			}
+			userProfile = UserProfile{
+				Subject: fmt.Sprintf("%d", ghUser.ID),
+				Email:   userEmail,
+				Name:    userName,
+				Picture: ghUser.Avatar,
+			}
 		} else {
 			return nil, fmt.Errorf("未实现对 '%s' 的用户信息解析", provider.Name)
 		}
@@ -489,4 +513,52 @@ func getUserProfile(ctx context.Context, provider *models.AuthProvider, oauth2Co
 		return nil, fmt.Errorf("未能获取到任何用户信息")
 	}
 	return &userProfile, nil
+}
+
+func fetchGitHubPrimaryEmail(ctx context.Context, oauth2Config *oauth2.Config, token *oauth2.Token) (string, error) {
+	client := oauth2Config.Client(ctx, token)
+	resp, err := client.Get("https://api.github.com/user/emails")
+	if err != nil {
+		return "", fmt.Errorf("无法获取 GitHub 邮箱信息")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("无法获取 GitHub 邮箱信息")
+	}
+
+	var emails []struct {
+		Email    string `json:"email"`
+		Primary  bool   `json:"primary"`
+		Verified bool   `json:"verified"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&emails); err != nil {
+		return "", fmt.Errorf("无法解析 GitHub 邮箱信息")
+	}
+
+	for _, item := range emails {
+		if item.Primary && item.Verified && strings.TrimSpace(item.Email) != "" {
+			return strings.TrimSpace(item.Email), nil
+		}
+	}
+	for _, item := range emails {
+		if item.Verified && strings.TrimSpace(item.Email) != "" {
+			return strings.TrimSpace(item.Email), nil
+		}
+	}
+	for _, item := range emails {
+		if strings.TrimSpace(item.Email) != "" {
+			return strings.TrimSpace(item.Email), nil
+		}
+	}
+
+	return "", nil
+}
+
+func optionalStringPtr(value string) *string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
 }

--- a/packages/server/internal/auth/handler.go
+++ b/packages/server/internal/auth/handler.go
@@ -72,7 +72,14 @@ type SessionResponseDTO struct {
 func getAPIBaseURL() string {
 	baseURL := strings.TrimSpace(os.Getenv("API_BASE_URL"))
 	if baseURL == "" {
-		baseURL = "http://localhost:8080"
+		port := strings.TrimSpace(os.Getenv("PORT"))
+		if port == "" {
+			port = "8080"
+		}
+		if strings.HasPrefix(port, ":") {
+			port = port[1:]
+		}
+		baseURL = fmt.Sprintf("http://localhost:%s", port)
 	}
 
 	return strings.TrimRight(baseURL, "/")

--- a/packages/server/internal/auth/handler_test.go
+++ b/packages/server/internal/auth/handler_test.go
@@ -154,3 +154,44 @@ func TestHandleRevokeOtherSessions_RevokesOnlyOtherSessions(t *testing.T) {
 		t.Fatalf("expected other session revoked")
 	}
 }
+
+func TestFindOrCreateUser_AllowsMultipleUsersWithoutEmail(t *testing.T) {
+	dsn := "file:" + uuid.NewString() + "?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.UserIdentityProvider{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+
+	profileA := &UserProfile{
+		Subject: "github-user-a",
+		Email:   "",
+		Name:    "User A",
+	}
+	profileB := &UserProfile{
+		Subject: "github-user-b",
+		Email:   "",
+		Name:    "User B",
+	}
+
+	userA, err := findOrCreateUser(db, "github", profileA)
+	if err != nil {
+		t.Fatalf("create user A: %v", err)
+	}
+	userB, err := findOrCreateUser(db, "github", profileB)
+	if err != nil {
+		t.Fatalf("create user B: %v", err)
+	}
+
+	if userA.Email != nil {
+		t.Fatalf("expected user A email to be nil, got %q", *userA.Email)
+	}
+	if userB.Email != nil {
+		t.Fatalf("expected user B email to be nil, got %q", *userB.Email)
+	}
+	if userA.ID == userB.ID {
+		t.Fatalf("expected different users to be created")
+	}
+}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { auth } from '$lib/stores/auth';
+import { resolveApiUrl } from '$lib/config/api';
 import { get } from 'svelte/store';
 
 // A simple flag to prevent multiple concurrent refresh attempts.
@@ -13,6 +14,8 @@ let isRefreshing = false;
  * @returns A Promise that resolves to the Response object.
  */
 export async function apiFetch(url: string, options: RequestInit = {}): Promise<Response> {
+	const resolvedUrl = resolveApiUrl(url);
+
 	// Get the current token from the store.
 	const token = get(auth).token;
 
@@ -22,9 +25,12 @@ export async function apiFetch(url: string, options: RequestInit = {}): Promise<
 		headers.set('Authorization', `Bearer ${token}`);
 	}
 	options.headers = headers;
+	if (options.credentials === undefined) {
+		options.credentials = 'include';
+	}
 
 	// Make the initial request.
-	let response = await fetch(url, options);
+	let response = await fetch(resolvedUrl, options);
 
 	// If the response is a 401 Unauthorized, and we haven't already started a refresh,
 	// try to refresh the token and retry the request.
@@ -42,7 +48,7 @@ export async function apiFetch(url: string, options: RequestInit = {}): Promise<
 
 				// ...and retry the original request.
 				console.log('Retrying original request with new token.');
-				response = await fetch(url, options);
+				response = await fetch(resolvedUrl, options);
 			}
 		} catch (error) {
 			// The refresh failed, the auth store will handle logout.

--- a/packages/web/src/lib/components/auth/SsoLoginBox.svelte
+++ b/packages/web/src/lib/components/auth/SsoLoginBox.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import * as m from '$paraglide/messages';
+  import { resolveApiUrl } from '$lib/config/api';
 
   type AuthProvider = {
     name: string;
@@ -20,7 +21,9 @@
 
   onMount(async () => {
     try {
-      const response = await fetch('/api/v1/auth/config');
+      const response = await fetch(resolveApiUrl('/api/v1/auth/config'), {
+        credentials: 'include'
+      });
       if (!response.ok) {
         throw new Error(m.sso_login_box_error_fetch_config());
       }

--- a/packages/web/src/lib/config/api.ts
+++ b/packages/web/src/lib/config/api.ts
@@ -1,0 +1,17 @@
+import { PUBLIC_API_BASE_URL } from '$env/static/public';
+
+const rawApiBaseUrl = PUBLIC_API_BASE_URL.trim();
+
+function trimTrailingSlash(value: string): string {
+	return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+export const apiBaseUrl = rawApiBaseUrl ? trimTrailingSlash(rawApiBaseUrl) : '';
+
+export function resolveApiUrl(path: string): string {
+	if (!path.startsWith('/')) {
+		return path;
+	}
+
+	return apiBaseUrl ? `${apiBaseUrl}${path}` : path;
+}

--- a/packages/web/src/lib/config/api.ts
+++ b/packages/web/src/lib/config/api.ts
@@ -1,6 +1,6 @@
 import { PUBLIC_API_BASE_URL } from '$env/static/public';
 
-const rawApiBaseUrl = PUBLIC_API_BASE_URL.trim();
+const rawApiBaseUrl = (PUBLIC_API_BASE_URL ?? '').trim();
 
 function trimTrailingSlash(value: string): string {
 	return value.endsWith('/') ? value.slice(0, -1) : value;

--- a/packages/web/src/lib/stores/auth.ts
+++ b/packages/web/src/lib/stores/auth.ts
@@ -1,5 +1,6 @@
 import { writable, get } from 'svelte/store';
 import { browser } from '$app/environment';
+import { resolveApiUrl } from '$lib/config/api';
 
 export type User = {
 	id: string;
@@ -35,8 +36,9 @@ function createAuthStore() {
 	});
 
 	async function _fetchUser(token: string): Promise<User> {
-		const response = await fetch('/api/v1/user/me', {
-			headers: { Authorization: `Bearer ${token}` }
+		const response = await fetch(resolveApiUrl('/api/v1/user/me'), {
+			headers: { Authorization: `Bearer ${token}` },
+			credentials: 'include'
 		});
 		if (!response.ok) throw new Error('Failed to fetch user profile');
 		const user: User = await response.json();
@@ -46,8 +48,9 @@ function createAuthStore() {
 	async function refreshToken() {
 		console.log('Attempting to refresh token...');
 		try {
-			const response = await fetch('/api/v1/auth/refresh', {
-				method: 'POST'
+			const response = await fetch(resolveApiUrl('/api/v1/auth/refresh'), {
+				method: 'POST',
+				credentials: 'include'
 			});
 			if (!response.ok) throw new Error('Refresh failed');
 
@@ -92,8 +95,9 @@ function createAuthStore() {
 
 		// Try to restore session from the backend using the refresh token cookie.
 		try {
-			const response = await fetch('/api/v1/auth/refresh', {
-				method: 'POST'
+			const response = await fetch(resolveApiUrl('/api/v1/auth/refresh'), {
+				method: 'POST',
+				credentials: 'include'
 			});
 
 			if (response.ok) {
@@ -153,8 +157,9 @@ function createAuthStore() {
 
 		try {
 			// Inform the backend to revoke the refresh token.
-			const response = await fetch('/api/v1/auth/logout', {
-				method: 'POST'
+			const response = await fetch(resolveApiUrl('/api/v1/auth/logout'), {
+				method: 'POST',
+				credentials: 'include'
 			});
 			if (!response.ok) {
 				// We can log this error, but we still want to clear the local state.

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import typography from "@tailwindcss/typography";
 
 export default {
   darkMode: "media",
@@ -25,5 +26,5 @@ export default {
     }
   },
 
-  plugins: [require("@tailwindcss/typography")]
+  plugins: [typography]
 } as Config;


### PR DESCRIPTION
## 变更说明

这次 PR 主要解决前后端分离场景下的认证与 API 访问问题，避免前后端默认都依赖 `localhost:8080` 的假设。

### 后端
- 新增 `API_BASE_URL` 配置，用于生成 OAuth/OIDC 登录入口和回调地址
- 新增 `PORT` 配置，服务不再固定监听 `8080`
- 登录配置接口返回的 SSO 地址改为基于 `API_BASE_URL` 生成

### 前端
- 新增 `PUBLIC_API_BASE_URL` 支持，用于在前后端不同域名时正确拼接 API 地址
- 统一通过 `resolveApiUrl` 处理 API 请求地址
- 对认证相关请求补充 `credentials: 'include'`，以支持跨域场景下的 refresh token cookie
- SSO 登录配置请求改为支持可配置后端地址

### 认证兼容性修复
- 创建用户时，空的 `email` / `displayName` / `avatar` 不再写入空字符串，而是写为 `nil`
- GitHub 登录在基础用户信息未返回邮箱时，补拉主邮箱地址
- 增加对应测试，覆盖“无邮箱用户也能正常创建”的情况

### 其他
- 调整 Tailwind typography 插件的导入方式，使配置风格与当前 ESM 方式保持一致

## 验证方式
- 本地开发环境下确认原有相对 `/api` 请求仍可正常工作
- 配置 `PUBLIC_API_BASE_URL` 后，前端可正确请求独立后端
- OAuth/OIDC 提供商回调地址改为基于 `API_BASE_URL` 生成
- GitHub 登录在未直接返回邮箱的情况下仍可正常完成登录