### PR TITLE
fix:Pin collaboration-cursor and refactor Editor class for readability

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -39,7 +39,7 @@
 		"@hocuspocus/provider": "^3.4.4",
 		"@tiptap/core": "^3.20.4",
 		"@tiptap/extension-collaboration": "^3.21.0",
-		"@tiptap/extension-collaboration-cursor": "^3.0.0",
+		"@tiptap/extension-collaboration-cursor": "3.0.0-next.6",
 		"@tiptap/extension-image": "^3.20.4",
 		"@tiptap/extension-link": "^3.20.4",
 		"@tiptap/extension-placeholder": "^3.20.4",
@@ -60,6 +60,7 @@
 	},
 	"pnpm": {
 		"overrides": {
+			"@tiptap/extension-collaboration-cursor": "3.0.0-next.6",
 			"kysely": ">=0.28.14",
 			"cookie@<0.7.0": "0.7.0",
 			"devalue@<5.6.4": "5.6.4",

--- a/packages/web/pnpm-lock.yaml
+++ b/packages/web/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@tiptap/extension-collaboration-cursor': 3.0.0-next.6
   kysely: '>=0.28.14'
   cookie@<0.7.0: 0.7.0
   devalue@<5.6.4: 5.6.4

--- a/packages/web/src/lib/components/editor/Editor.svelte
+++ b/packages/web/src/lib/components/editor/Editor.svelte
@@ -525,6 +525,23 @@
 			);
 		}
 
+		const editorRootClass = [
+			'tiptap',
+			'min-h-full',
+			'w-full',
+			'px-4',
+			'py-6',
+			'text-base',
+			'text-zinc-800',
+			'outline-none',
+			'dark:text-zinc-100',
+			'sm:px-8',
+			'lg:px-[14%]',
+			collaboration?.doc ? 'cw-collab-mode' : ''
+		]
+			.filter(Boolean)
+			.join(' ');
+
 		editor = new Editor({
 			element: editorElement,
 			editable: !readOnly,
@@ -608,7 +625,7 @@
 					}
 				},
 				attributes: {
-					class: `tiptap ${collaboration?.doc ? 'cw-collab-mode' : ''} min-h-full w-full px-4 py-6 text-base text-zinc-800 outline-none dark:text-zinc-100 sm:px-8 lg:px-[14%}`
+					class: editorRootClass
 				}
 			},
 			onUpdate: ({ editor }) => {


### PR DESCRIPTION
修复编辑器协作回归问题。将 `@tiptap/extension-collaboration-cursor` 固定回已验证正常的 `3.0.0-next.6`，避免依赖漂移到 `3.0.0` 后触发协作异常；同时调整编辑器根节点 class 的构造方式，避免协作模式下正文横向 padding 类意外丢失。