### PR TITLE
bug fix:Make local collaboration cursor theme-aware

### DIFF
--- a/packages/web/src/lib/components/editor/Editor.svelte
+++ b/packages/web/src/lib/components/editor/Editor.svelte
@@ -112,8 +112,7 @@
 	const imageUploadAccept = '.png,.jpg,.jpeg,.webp,.gif,image/png,image/jpeg,image/webp,image/gif';
 	const headingLevels = [1, 2, 3, 4, 5, 6] as const;
 	const externalImagePathPattern = /\.(avif|gif|jpe?g|png|svg|webp)(?:$|[?#])/i;
-	const LOCAL_CURSOR_COLOR_LIGHT = '#06b6d4';
-	const LOCAL_CURSOR_COLOR_DARK = '#67e8f9';
+	const LOCAL_CURSOR_COLOR = '#06b6d4';
 	const remoteCursorPalette = [
 		'#2563eb',
 		'#9333ea',
@@ -135,16 +134,6 @@
 		return hash;
 	}
 
-	function getLocalCursorColor() {
-		if (typeof document === 'undefined') {
-			return LOCAL_CURSOR_COLOR_LIGHT;
-		}
-
-		return document.documentElement.classList.contains('dark')
-			? LOCAL_CURSOR_COLOR_DARK
-			: LOCAL_CURSOR_COLOR_LIGHT;
-	}
-
 	function getCollaborationUser() {
 		const authState = $auth;
 		const id = authState.user?.id ?? collaboration?.provider?.awareness?.clientID?.toString() ?? 'unknown';
@@ -152,7 +141,7 @@
 			authState.user?.displayName?.trim() ||
 			authState.user?.email?.trim() ||
 			`协作者 ${id.slice(0, 6)}`;
-		const color = getLocalCursorColor();
+		const color = LOCAL_CURSOR_COLOR;
 
 		return { id, name, color };
 	}
@@ -169,8 +158,8 @@
 		cursor.classList.add('collaboration-cursor__caret');
 		const isLocal = user.id === localUserId;
 		const effectiveColor = isLocal
-			? getLocalCursorColor()
-			: getRemoteCursorColor(user.id ?? user.name ?? 'remote-user');
+			? LOCAL_CURSOR_COLOR
+			: (user.color ?? getRemoteCursorColor(user.id ?? user.name ?? 'remote-user'));
 		cursor.style.setProperty('--user-color', effectiveColor);
 
 		const label = document.createElement('span');

--- a/packages/web/src/lib/components/editor/Editor.svelte
+++ b/packages/web/src/lib/components/editor/Editor.svelte
@@ -112,7 +112,8 @@
 	const imageUploadAccept = '.png,.jpg,.jpeg,.webp,.gif,image/png,image/jpeg,image/webp,image/gif';
 	const headingLevels = [1, 2, 3, 4, 5, 6] as const;
 	const externalImagePathPattern = /\.(avif|gif|jpe?g|png|svg|webp)(?:$|[?#])/i;
-	const LOCAL_CURSOR_COLOR = '#16a34a';
+	const LOCAL_CURSOR_COLOR_LIGHT = '#06b6d4';
+	const LOCAL_CURSOR_COLOR_DARK = '#67e8f9';
 	const remoteCursorPalette = [
 		'#2563eb',
 		'#9333ea',
@@ -134,6 +135,16 @@
 		return hash;
 	}
 
+	function getLocalCursorColor() {
+		if (typeof document === 'undefined') {
+			return LOCAL_CURSOR_COLOR_LIGHT;
+		}
+
+		return document.documentElement.classList.contains('dark')
+			? LOCAL_CURSOR_COLOR_DARK
+			: LOCAL_CURSOR_COLOR_LIGHT;
+	}
+
 	function getCollaborationUser() {
 		const authState = $auth;
 		const id = authState.user?.id ?? collaboration?.provider?.awareness?.clientID?.toString() ?? 'unknown';
@@ -141,7 +152,7 @@
 			authState.user?.displayName?.trim() ||
 			authState.user?.email?.trim() ||
 			`协作者 ${id.slice(0, 6)}`;
-		const color = LOCAL_CURSOR_COLOR;
+		const color = getLocalCursorColor();
 
 		return { id, name, color };
 	}
@@ -158,7 +169,7 @@
 		cursor.classList.add('collaboration-cursor__caret');
 		const isLocal = user.id === localUserId;
 		const effectiveColor = isLocal
-			? LOCAL_CURSOR_COLOR
+			? getLocalCursorColor()
 			: getRemoteCursorColor(user.id ?? user.name ?? 'remote-user');
 		cursor.style.setProperty('--user-color', effectiveColor);
 

--- a/packages/web/src/lib/components/editor/editor-content.css
+++ b/packages/web/src/lib/components/editor/editor-content.css
@@ -12,6 +12,9 @@
 	--editor-table-head: rgb(244 244 245);
 	--editor-link: rgb(13 148 136);
 	--editor-selected-cell: rgb(13 148 136 / 0.12);
+	--editor-collab-local-caret: #06b6d4;
+	--editor-collab-selection-mix: 20%;
+	--editor-collab-selection-alpha: 24%;
 	color: var(--editor-text);
 	line-height: 2.1;
 	min-height: 100%;
@@ -32,7 +35,16 @@
 		--editor-table-head: rgb(39 39 42);
 		--editor-link: rgb(45 212 191);
 		--editor-selected-cell: rgb(45 212 191 / 0.18);
+		--editor-collab-local-caret: #67e8f9;
+		--editor-collab-selection-mix: 32%;
+		--editor-collab-selection-alpha: 18%;
 	}
+}
+
+.dark .tiptap {
+	--editor-collab-local-caret: #67e8f9;
+	--editor-collab-selection-mix: 32%;
+	--editor-collab-selection-alpha: 18%;
 }
 
 .tiptap:focus {
@@ -40,7 +52,7 @@
 }
 
 .tiptap.cw-collab-mode {
-	caret-color: #16a34a;
+	caret-color: var(--editor-collab-local-caret);
 }
 
 .tiptap p.is-editor-empty:first-child::before {
@@ -333,7 +345,19 @@
 }
 
 .tiptap .collaboration-cursor__selection {
-	background: color-mix(in srgb, var(--user-color) 28%, transparent);
+	background: color-mix(
+		in srgb,
+		var(--user-color) var(--editor-collab-selection-mix),
+		transparent
+	);
+}
+
+.dark .tiptap .collaboration-cursor__selection {
+	background: color-mix(
+		in srgb,
+		white var(--editor-collab-selection-alpha),
+		var(--user-color)
+	);
 }
 
 .tiptap .cw-cursor-label {


### PR DESCRIPTION
Use separate light/dark colors for the local cursor and detect theme via document.documentElement.classList.contains('dark'). Add CSS variables (--editor-collab-local-caret, --editor-collab-selection-mix, --editor-collab-selection-alpha) and update caret color and selection blending to respect the active theme.