### PR TITLE
fix: resolve image export and collaboration switching issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,10 @@ MEDIA_AVATAR_SIGN_TTL_SECONDS=300
 # 头像最大字节数，默认 2097152（2MB）
 MEDIA_AVATAR_MAX_BYTES=2097152
 
+# ---- 文档图片上传 ----
+# 文档编辑器内图片上传最大字节数，默认 5242880（5MB）
+MEDIA_DOCUMENT_IMAGE_MAX_BYTES=5242880
+
 
 # ---- 媒体存储 ----
 # 可选: local | r2 | s3 | cos

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 - `PUBLIC_AVATAR_MAX_BYTES=2097152`
 - `PUBLIC_AVATAR_OUTPUT_SIZE=512`
 
+服务端媒体相关环境变量里，文档图片上传上限可通过 `MEDIA_DOCUMENT_IMAGE_MAX_BYTES` 配置；当前默认值为 `5242880`（5MB）。
+
 常用构建命令：
 
 - Cloudflare Pages：`pnpm install --frozen-lockfile && pnpm run build`

--- a/packages/server/internal/media/document_image_upload.go
+++ b/packages/server/internal/media/document_image_upload.go
@@ -29,7 +29,8 @@ const (
 	documentImageModeManagedAsset = "managed_asset"
 	documentImageModeExternalURL  = "external_url"
 
-	documentImageTargetManagedR2 = "managed-r2"
+	documentImageTargetManagedR2       = "managed-r2"
+	defaultDocumentImageMaxBytes int64 = 5 * 1024 * 1024
 )
 
 type DocumentImageErrorCode string
@@ -40,6 +41,7 @@ const (
 	DocumentImageErrProviderConfig     DocumentImageErrorCode = "provider_config_invalid"
 	DocumentImageErrProviderNotReady   DocumentImageErrorCode = "provider_not_configured"
 	DocumentImageErrProviderUploadFail DocumentImageErrorCode = "provider_upload_failed"
+	DocumentImageErrFileTooLarge       DocumentImageErrorCode = "file_too_large"
 )
 
 type DocumentImageError struct {
@@ -571,6 +573,13 @@ func UploadDocumentImage(ctx context.Context, req UploadDocumentImageRequest) (*
 	if req.FileHeader == nil {
 		return nil, ErrFileRequired
 	}
+	maxBytes := documentImageMaxBytes()
+	if req.FileHeader.Size > 0 && req.FileHeader.Size > maxBytes {
+		return nil, newDocumentImageError(
+			DocumentImageErrFileTooLarge,
+			fmt.Sprintf("document image file too large: max %d bytes", maxBytes),
+		)
+	}
 
 	targetID := normalizeDocumentImageTargetID(req.TargetID)
 	if targetID == "" {
@@ -590,4 +599,16 @@ func UploadDocumentImage(ctx context.Context, req UploadDocumentImageRequest) (*
 	}
 
 	return uploader.Upload(ctx, req)
+}
+
+func documentImageMaxBytes() int64 {
+	raw := strings.TrimSpace(os.Getenv("MEDIA_DOCUMENT_IMAGE_MAX_BYTES"))
+	if raw == "" {
+		return defaultDocumentImageMaxBytes
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || parsed <= 0 {
+		return defaultDocumentImageMaxBytes
+	}
+	return parsed
 }

--- a/packages/server/internal/media/handler.go
+++ b/packages/server/internal/media/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log"
+	"strings"
 	"time"
 
 	"g.co1d.in/Coldin04/CyimeWrite/server/internal/models"
@@ -760,6 +761,9 @@ func UploadDocumentImageHandler(c *fiber.Ctx) error {
 			case DocumentImageErrProviderUploadFail:
 				status = fiber.StatusBadGateway
 				code = "DOCUMENT_IMAGE_PROVIDER_UPLOAD_FAILED"
+			case DocumentImageErrFileTooLarge:
+				status = fiber.StatusRequestEntityTooLarge
+				code = "DOCUMENT_IMAGE_FILE_TOO_LARGE"
 			}
 		case errors.Is(err, context.Canceled):
 			status = fiber.StatusRequestTimeout
@@ -767,6 +771,9 @@ func UploadDocumentImageHandler(c *fiber.Ctx) error {
 		case errors.As(err, &unsupported):
 			status = fiber.StatusBadRequest
 			code = "DOCUMENT_IMAGE_UNSUPPORTED_FILE_TYPE"
+		case strings.Contains(err.Error(), "request body too large") || strings.Contains(err.Error(), "413"):
+			status = fiber.StatusRequestEntityTooLarge
+			code = "DOCUMENT_IMAGE_FILE_TOO_LARGE"
 		}
 		return c.Status(status).JSON(ErrorResponse{
 			Error:   "Upload Failed",

--- a/packages/web/src/lib/api/editor.ts
+++ b/packages/web/src/lib/api/editor.ts
@@ -60,6 +60,7 @@ export type UploadDocumentImageResponse = {
 
 export type EditorAPIError = Error & {
 	code?: string;
+	status?: number;
 };
 
 async function parseJSONResponse<T>(response: Response, fallbackMessage: string): Promise<T> {
@@ -179,6 +180,13 @@ export async function pasteDocumentImage(
 	});
 
 	if (!response.ok) {
+		if (response.status === 413) {
+			const apiError = new Error('Image is too large') as EditorAPIError;
+			apiError.code = 'DOCUMENT_IMAGE_FILE_TOO_LARGE';
+			apiError.status = response.status;
+			throw apiError;
+		}
+
 		const error = await parseJSONResponse<{ message?: string; code?: string }>(
 			response,
 			'Failed to upload pasted image'
@@ -187,6 +195,7 @@ export async function pasteDocumentImage(
 			error.message || 'Failed to upload pasted image'
 		) as EditorAPIError;
 		apiError.code = error.code;
+		apiError.status = response.status;
 		throw apiError;
 	}
 

--- a/packages/web/src/lib/components/editor/Editor.svelte
+++ b/packages/web/src/lib/components/editor/Editor.svelte
@@ -719,7 +719,16 @@
 		}
 	}
 
-	onMount(() => {
+	let editorCleanup: (() => void) | null = null;
+
+	function destroyEditor() {
+		editorCleanup?.();
+		editorCleanup = null;
+		editor?.destroy();
+		editor = null;
+	}
+
+	function createEditor() {
 		if (!editorElement) {
 			return;
 		}
@@ -809,7 +818,7 @@
 			.filter(Boolean)
 			.join(' ');
 
-		editor = new Editor({
+		const editorInstance = new Editor({
 			element: editorElement,
 			editable: !readOnly,
 			extensions,
@@ -926,17 +935,19 @@
 			}
 		});
 
+		editor = editorInstance;
+
 		const reconcileCollaborationContent = async () => {
-			if (!editor || !collaboration?.doc) {
+			if (editor !== editorInstance || !collaboration?.doc) {
 				return;
 			}
 
 			if (!hasSeededCollaborationContent) {
 				hasSeededCollaborationContent = true;
-				const currentDoc = normalizeDoc(editor.getJSON());
+				const currentDoc = normalizeDoc(editorInstance.getJSON());
 				if (!hasMeaningfulContent(currentDoc) && hasMeaningfulContent(content)) {
 					lastSyncedContent = serializeDoc(content);
-					editor.commands.setContent(toTiptapContent(content), { emitUpdate: false });
+					editorInstance.commands.setContent(toTiptapContent(content), { emitUpdate: false });
 				}
 			}
 
@@ -945,294 +956,14 @@
 			}
 
 			hasHydratedManagedImages = true;
-			const currentDoc = normalizeDoc(editor.getJSON());
+			const currentDoc = normalizeDoc(editorInstance.getJSON());
 			const hydrated = await hydrateManagedContent(currentDoc);
-			if (serializeDoc(hydrated) === serializeDoc(currentDoc)) {
+			if (editor !== editorInstance || serializeDoc(hydrated) === serializeDoc(currentDoc)) {
 				return;
 			}
 
 			lastSyncedContent = serializeDoc(hydrated);
-			editor.commands.setContent(toTiptapContent(hydrated), { emitUpdate: false });
-		};
-
-		const handleSynced = ({ state }: { state: boolean }) => {
-			if (state) {
-				void reconcileCollaborationContent();
-			}
-		};
-
-		if (collaboration?.provider) {
-			collaboration.provider.on('synced', handleSynced);
-			if (collaboration.provider.synced) {
-				void reconcileCollaborationContent();
-			}
-		} else if (collaboration?.doc) {
-			void reconcileCollaborationContent();
-		}
-
-		return () => {
-			collaboration?.provider?.off('synced', handleSynced);
-			editor?.destroy();
-			editor = null;
-		};
-	});
-
-	// Handle collaboration mode changes by recreating the editor
-	let previousCollaborationKey = collaboration?.doc ? `collab:${documentId}` : `local:${documentId}`;
-
-	$effect(() => {
-		const currentKey = collaboration?.doc ? `collab:${documentId}` : `local:${documentId}`;
-		if (currentKey === previousCollaborationKey || !editorElement) {
-			previousCollaborationKey = currentKey;
-			return;
-		}
-
-		// Save current content before destroying the editor
-		if (editor) {
-			const currentContent = editor.getJSON();
-			if (serializeDoc(currentContent) !== lastSyncedContent) {
-				lastSyncedContent = serializeDoc(currentContent);
-				onContentChange?.(currentContent);
-			}
-		}
-
-		// Destroy old editor
-		editor?.destroy();
-		editor = null;
-		hasSeededCollaborationContent = false;
-		hasHydratedManagedImages = false;
-		previousCollaborationKey = currentKey;
-
-		// Recreate editor with new collaboration state
-		lastSyncedContent = serializeDoc(content);
-		const collaborationUser = getCollaborationUser();
-		const extensions: any[] = [
-			StarterKit.configure({
-				heading: {
-					levels: [...headingLevels]
-				},
-				link: false,
-				...(collaboration?.doc ? { undoRedo: false } : {})
-			}),
-			CyImage.configure({
-				inline: false,
-				allowBase64: true
-			}),
-			Link.configure({
-				openOnClick: false,
-				autolink: true,
-				defaultProtocol: 'https'
-			}),
-			Mathematics.configure({
-				katexOptions: {
-					throwOnError: false,
-					strict: 'ignore'
-				},
-				...(readOnly
-					? {}
-					: {
-							blockOptions: {
-								onClick: (node, pos) => {
-									const latex =
-										typeof node.attrs?.latex === 'string' ? node.attrs.latex : '';
-									openMathDialog('block', latex, pos);
-								}
-							}
-						})
-			}),
-			Table.configure({
-				resizable: true,
-				HTMLAttributes: {
-					class: 'cw-editor-table'
-				}
-			}),
-			TableRow,
-			TableHeader,
-			TableCell,
-			...(!readOnly
-				? [
-						Placeholder.configure({
-							placeholder: m.editor_placeholder()
-						})
-					]
-				: [])
-		];
-
-		if (collaboration?.doc) {
-			collaboration.provider?.setAwarenessField('user', collaborationUser);
-			extensions.push(
-				Collaboration.configure({
-					document: collaboration.doc
-				}),
-				CollaborationCursor.configure({
-					provider: collaboration.provider,
-					user: collaborationUser,
-					render: (user) => renderCollaborationCursor(user, collaborationUser.id)
-				})
-			);
-		}
-
-		const editorRootClass = [
-			'tiptap',
-			'min-h-full',
-			'w-full',
-			'px-4',
-			'py-6',
-			'text-base',
-			'text-zinc-800',
-			'outline-none',
-			'dark:text-zinc-100',
-			'sm:px-8',
-			'lg:px-[14%]',
-			collaboration?.doc ? 'cw-collab-mode' : ''
-		]
-			.filter(Boolean)
-			.join(' ');
-
-		editor = new Editor({
-			element: editorElement,
-			editable: !readOnly,
-			extensions,
-			content: collaboration?.doc ? undefined : toTiptapContent(content),
-			editorProps: {
-				transformPastedHTML: (html) => sanitizePastedHTML(html),
-				handleDOMEvents: {
-					paste: (_view, event) => {
-						if (readOnly) {
-							return false;
-						}
-						const clipboardEvent = event as ClipboardEvent;
-						const clipboard = clipboardEvent.clipboardData;
-						if (!clipboard) return false;
-
-						const clipboardFiles = collectClipboardImageFiles(clipboard);
-						if (clipboardFiles.length > 0) {
-							clipboardEvent.preventDefault();
-							void (async () => {
-								await uploadAndInsertImages(clipboardFiles, 'paste');
-							})();
-							return true;
-						}
-
-						if (hasClipboardFiles(clipboard)) {
-							clipboardEvent.preventDefault();
-							toast.error(m.editor_paste_only_support_image_files());
-							return true;
-						}
-
-						const html = clipboard.getData('text/html');
-						const imageSources = extractImageSourcesFromHTML(html).filter((src) =>
-							src.startsWith('data:image/') || src.startsWith('http://') || src.startsWith('https://')
-						);
-						if (imageSources.length > 0) {
-							clipboardEvent.preventDefault();
-							void (async () => {
-								let blockedSourceCount = 0;
-								for (const src of imageSources) {
-									const file = await srcToUploadFile(src);
-									if (!file) {
-										blockedSourceCount += 1;
-										continue;
-									}
-									await uploadAndInsertImage(file, 'paste');
-								}
-
-								if (blockedSourceCount > 0) {
-									toast.error(
-										'检测到不支持或无法读取的粘贴图片内容，已跳过。仅支持 PNG/JPG/WebP/GIF。'
-									);
-								}
-							})();
-							return true;
-						}
-
-						const text = clipboard.getData('text/plain');
-						if (isExternalImageURL(text.trim())) {
-							clipboardEvent.preventDefault();
-							insertExternalImage(text);
-							return true;
-						}
-
-						const pastedMath = parsePastedMathExpression(text);
-						if (pastedMath) {
-							clipboardEvent.preventDefault();
-							const chain = editor?.chain().focus();
-							const succeeded =
-								pastedMath.mode === 'block'
-									? chain?.insertBlockMath({ latex: pastedMath.latex }).run()
-									: chain?.insertInlineMath({ latex: pastedMath.latex }).run();
-							if (!succeeded) {
-								toast.error(m.editor_math_insert_failed());
-							}
-							return true;
-						}
-
-						if (!looksLikeMarkdown(text)) return false;
-
-						const rendered = marked.parse(text, {
-							async: false,
-							gfm: true,
-							breaks: true
-						});
-						if (typeof rendered !== 'string') return false;
-
-						clipboardEvent.preventDefault();
-						editor
-							?.chain()
-							.focus()
-							.insertContent(sanitizePastedHTML(rendered))
-							.run();
-						return true;
-					}
-				},
-				attributes: {
-					class: editorRootClass
-				}
-			},
-			onUpdate: ({ editor }) => {
-				if (readOnly) {
-					return;
-				}
-				if (!isNormalizingMathInput && normalizeMarkdownMathInput(editor)) {
-					return;
-				}
-				const nextContent = editor.getJSON();
-				lastSyncedContent = serializeDoc(nextContent);
-				onContentChange?.(nextContent);
-				editorRevision += 1;
-			},
-			onSelectionUpdate: () => {
-				editorRevision += 1;
-			}
-		});
-
-		const reconcileCollaborationContent = async () => {
-			if (!editor || !collaboration?.doc) {
-				return;
-			}
-
-			if (!hasSeededCollaborationContent) {
-				hasSeededCollaborationContent = true;
-				const currentDoc = normalizeDoc(editor.getJSON());
-				if (!hasMeaningfulContent(currentDoc) && hasMeaningfulContent(content)) {
-					lastSyncedContent = serializeDoc(content);
-					editor.commands.setContent(toTiptapContent(content), { emitUpdate: false });
-				}
-			}
-
-			if (hasHydratedManagedImages || !hydrateManagedContent) {
-				return;
-			}
-
-			hasHydratedManagedImages = true;
-			const currentDoc = normalizeDoc(editor.getJSON());
-			const hydrated = await hydrateManagedContent(currentDoc);
-			if (serializeDoc(hydrated) === serializeDoc(currentDoc)) {
-				return;
-			}
-
-			lastSyncedContent = serializeDoc(hydrated);
-			editor.commands.setContent(toTiptapContent(hydrated), { emitUpdate: false });
+			editorInstance.commands.setContent(toTiptapContent(hydrated), { emitUpdate: false });
 		};
 
 		const handleSynced = ({ state }: { state: boolean }) => {
@@ -1251,9 +982,51 @@
 			void reconcileCollaborationContent();
 		}
 
-		return () => {
+		editorCleanup = () => {
 			provider?.off('synced', handleSynced);
 		};
+	}
+
+	function getCollaborationKey() {
+		return collaboration?.doc ? `collab:${documentId}` : `local:${documentId}`;
+	}
+
+	onMount(() => {
+		previousCollaborationKey = getCollaborationKey();
+		createEditor();
+
+		return () => {
+			destroyEditor();
+		};
+	});
+
+	// Handle collaboration mode changes by recreating the editor
+	let previousCollaborationKey = '';
+
+	$effect(() => {
+		const currentKey = getCollaborationKey();
+		if (currentKey === previousCollaborationKey || !editorElement) {
+			previousCollaborationKey = currentKey;
+			return;
+		}
+
+		// Save current content before destroying the editor
+		if (editor) {
+			const currentContent = editor.getJSON();
+			if (serializeDoc(currentContent) !== lastSyncedContent) {
+				lastSyncedContent = serializeDoc(currentContent);
+				onContentChange?.(currentContent);
+			}
+		}
+
+		// Destroy old editor
+		destroyEditor();
+		hasSeededCollaborationContent = false;
+		hasHydratedManagedImages = false;
+		previousCollaborationKey = currentKey;
+
+		// Recreate editor with new collaboration state
+		createEditor();
 	});
 
 	$effect(() => {

--- a/packages/web/src/lib/components/editor/Editor.svelte
+++ b/packages/web/src/lib/components/editor/Editor.svelte
@@ -598,6 +598,8 @@
 		switch (apiError?.code) {
 			case 'DOCUMENT_IMAGE_UNSUPPORTED_FILE_TYPE':
 				return m.editor_paste_only_support_image_files();
+			case 'DOCUMENT_IMAGE_FILE_TOO_LARGE':
+				return m.editor_image_file_too_large();
 			case 'DOCUMENT_IMAGE_PROVIDER_NOT_CONFIGURED':
 			case 'DOCUMENT_IMAGE_TARGET_NOT_SUPPORTED':
 				return m.common_unknown_error();
@@ -1239,14 +1241,19 @@
 			}
 		};
 
-		if (collaboration?.provider) {
-			collaboration.provider.on('synced', handleSynced);
-			if (collaboration.provider.synced) {
+		const provider = collaboration?.provider;
+		if (provider) {
+			provider.on('synced', handleSynced);
+			if (provider.synced) {
 				void reconcileCollaborationContent();
 			}
 		} else if (collaboration?.doc) {
 			void reconcileCollaborationContent();
 		}
+
+		return () => {
+			provider?.off('synced', handleSynced);
+		};
 	});
 
 	$effect(() => {

--- a/packages/web/src/lib/components/editor/Editor.svelte
+++ b/packages/web/src/lib/components/editor/Editor.svelte
@@ -975,6 +975,280 @@
 		};
 	});
 
+	// Handle collaboration mode changes by recreating the editor
+	let previousCollaborationKey = collaboration?.doc ? `collab:${documentId}` : `local:${documentId}`;
+
+	$effect(() => {
+		const currentKey = collaboration?.doc ? `collab:${documentId}` : `local:${documentId}`;
+		if (currentKey === previousCollaborationKey || !editorElement) {
+			previousCollaborationKey = currentKey;
+			return;
+		}
+
+		// Save current content before destroying the editor
+		if (editor) {
+			const currentContent = editor.getJSON();
+			if (serializeDoc(currentContent) !== lastSyncedContent) {
+				lastSyncedContent = serializeDoc(currentContent);
+				onContentChange?.(currentContent);
+			}
+		}
+
+		// Destroy old editor
+		editor?.destroy();
+		editor = null;
+		hasSeededCollaborationContent = false;
+		hasHydratedManagedImages = false;
+		previousCollaborationKey = currentKey;
+
+		// Recreate editor with new collaboration state
+		lastSyncedContent = serializeDoc(content);
+		const collaborationUser = getCollaborationUser();
+		const extensions: any[] = [
+			StarterKit.configure({
+				heading: {
+					levels: [...headingLevels]
+				},
+				link: false,
+				...(collaboration?.doc ? { undoRedo: false } : {})
+			}),
+			CyImage.configure({
+				inline: false,
+				allowBase64: true
+			}),
+			Link.configure({
+				openOnClick: false,
+				autolink: true,
+				defaultProtocol: 'https'
+			}),
+			Mathematics.configure({
+				katexOptions: {
+					throwOnError: false,
+					strict: 'ignore'
+				},
+				...(readOnly
+					? {}
+					: {
+							blockOptions: {
+								onClick: (node, pos) => {
+									const latex =
+										typeof node.attrs?.latex === 'string' ? node.attrs.latex : '';
+									openMathDialog('block', latex, pos);
+								}
+							}
+						})
+			}),
+			Table.configure({
+				resizable: true,
+				HTMLAttributes: {
+					class: 'cw-editor-table'
+				}
+			}),
+			TableRow,
+			TableHeader,
+			TableCell,
+			...(!readOnly
+				? [
+						Placeholder.configure({
+							placeholder: m.editor_placeholder()
+						})
+					]
+				: [])
+		];
+
+		if (collaboration?.doc) {
+			collaboration.provider?.setAwarenessField('user', collaborationUser);
+			extensions.push(
+				Collaboration.configure({
+					document: collaboration.doc
+				}),
+				CollaborationCursor.configure({
+					provider: collaboration.provider,
+					user: collaborationUser,
+					render: (user) => renderCollaborationCursor(user, collaborationUser.id)
+				})
+			);
+		}
+
+		const editorRootClass = [
+			'tiptap',
+			'min-h-full',
+			'w-full',
+			'px-4',
+			'py-6',
+			'text-base',
+			'text-zinc-800',
+			'outline-none',
+			'dark:text-zinc-100',
+			'sm:px-8',
+			'lg:px-[14%]',
+			collaboration?.doc ? 'cw-collab-mode' : ''
+		]
+			.filter(Boolean)
+			.join(' ');
+
+		editor = new Editor({
+			element: editorElement,
+			editable: !readOnly,
+			extensions,
+			content: collaboration?.doc ? undefined : toTiptapContent(content),
+			editorProps: {
+				transformPastedHTML: (html) => sanitizePastedHTML(html),
+				handleDOMEvents: {
+					paste: (_view, event) => {
+						if (readOnly) {
+							return false;
+						}
+						const clipboardEvent = event as ClipboardEvent;
+						const clipboard = clipboardEvent.clipboardData;
+						if (!clipboard) return false;
+
+						const clipboardFiles = collectClipboardImageFiles(clipboard);
+						if (clipboardFiles.length > 0) {
+							clipboardEvent.preventDefault();
+							void (async () => {
+								await uploadAndInsertImages(clipboardFiles, 'paste');
+							})();
+							return true;
+						}
+
+						if (hasClipboardFiles(clipboard)) {
+							clipboardEvent.preventDefault();
+							toast.error(m.editor_paste_only_support_image_files());
+							return true;
+						}
+
+						const html = clipboard.getData('text/html');
+						const imageSources = extractImageSourcesFromHTML(html).filter((src) =>
+							src.startsWith('data:image/') || src.startsWith('http://') || src.startsWith('https://')
+						);
+						if (imageSources.length > 0) {
+							clipboardEvent.preventDefault();
+							void (async () => {
+								let blockedSourceCount = 0;
+								for (const src of imageSources) {
+									const file = await srcToUploadFile(src);
+									if (!file) {
+										blockedSourceCount += 1;
+										continue;
+									}
+									await uploadAndInsertImage(file, 'paste');
+								}
+
+								if (blockedSourceCount > 0) {
+									toast.error(
+										'检测到不支持或无法读取的粘贴图片内容，已跳过。仅支持 PNG/JPG/WebP/GIF。'
+									);
+								}
+							})();
+							return true;
+						}
+
+						const text = clipboard.getData('text/plain');
+						if (isExternalImageURL(text.trim())) {
+							clipboardEvent.preventDefault();
+							insertExternalImage(text);
+							return true;
+						}
+
+						const pastedMath = parsePastedMathExpression(text);
+						if (pastedMath) {
+							clipboardEvent.preventDefault();
+							const chain = editor?.chain().focus();
+							const succeeded =
+								pastedMath.mode === 'block'
+									? chain?.insertBlockMath({ latex: pastedMath.latex }).run()
+									: chain?.insertInlineMath({ latex: pastedMath.latex }).run();
+							if (!succeeded) {
+								toast.error(m.editor_math_insert_failed());
+							}
+							return true;
+						}
+
+						if (!looksLikeMarkdown(text)) return false;
+
+						const rendered = marked.parse(text, {
+							async: false,
+							gfm: true,
+							breaks: true
+						});
+						if (typeof rendered !== 'string') return false;
+
+						clipboardEvent.preventDefault();
+						editor
+							?.chain()
+							.focus()
+							.insertContent(sanitizePastedHTML(rendered))
+							.run();
+						return true;
+					}
+				},
+				attributes: {
+					class: editorRootClass
+				}
+			},
+			onUpdate: ({ editor }) => {
+				if (readOnly) {
+					return;
+				}
+				if (!isNormalizingMathInput && normalizeMarkdownMathInput(editor)) {
+					return;
+				}
+				const nextContent = editor.getJSON();
+				lastSyncedContent = serializeDoc(nextContent);
+				onContentChange?.(nextContent);
+				editorRevision += 1;
+			},
+			onSelectionUpdate: () => {
+				editorRevision += 1;
+			}
+		});
+
+		const reconcileCollaborationContent = async () => {
+			if (!editor || !collaboration?.doc) {
+				return;
+			}
+
+			if (!hasSeededCollaborationContent) {
+				hasSeededCollaborationContent = true;
+				const currentDoc = normalizeDoc(editor.getJSON());
+				if (!hasMeaningfulContent(currentDoc) && hasMeaningfulContent(content)) {
+					lastSyncedContent = serializeDoc(content);
+					editor.commands.setContent(toTiptapContent(content), { emitUpdate: false });
+				}
+			}
+
+			if (hasHydratedManagedImages || !hydrateManagedContent) {
+				return;
+			}
+
+			hasHydratedManagedImages = true;
+			const currentDoc = normalizeDoc(editor.getJSON());
+			const hydrated = await hydrateManagedContent(currentDoc);
+			if (serializeDoc(hydrated) === serializeDoc(currentDoc)) {
+				return;
+			}
+
+			lastSyncedContent = serializeDoc(hydrated);
+			editor.commands.setContent(toTiptapContent(hydrated), { emitUpdate: false });
+		};
+
+		const handleSynced = ({ state }: { state: boolean }) => {
+			if (state) {
+				void reconcileCollaborationContent();
+			}
+		};
+
+		if (collaboration?.provider) {
+			collaboration.provider.on('synced', handleSynced);
+			if (collaboration.provider.synced) {
+				void reconcileCollaborationContent();
+			}
+		} else if (collaboration?.doc) {
+			void reconcileCollaborationContent();
+		}
+	});
+
 	$effect(() => {
 		if (!editor || collaboration?.doc) {
 			return;

--- a/packages/web/src/lib/export/documentExport.ts
+++ b/packages/web/src/lib/export/documentExport.ts
@@ -256,6 +256,16 @@ export function exportMarkdown(contentJson: JSONContent): string {
 				lines.push('$$');
 				lines.push('');
 				return;
+			case 'image': {
+				const src = typeof node.attrs?.src === 'string' ? node.attrs.src : '';
+				if (src) {
+					const title = typeof node.attrs?.title === 'string' ? node.attrs.title : '';
+					const alt = typeof node.attrs?.alt === 'string' ? node.attrs.alt : title;
+					lines.push(`![${escapeMarkdown(alt)}](${src})`);
+					lines.push('');
+				}
+				return;
+			}
 			default: {
 				const inline = renderInline(node.content ?? []);
 				if (inline.trim() !== '') {
@@ -418,6 +428,14 @@ export function exportBBCode(contentJson: JSONContent): string {
 			case 'table':
 				renderTable(node);
 				return;
+			case 'image': {
+				const src = typeof node.attrs?.src === 'string' ? node.attrs.src : '';
+				if (src) {
+					lines.push(`[img]${src}[/img]`);
+					lines.push('');
+				}
+				return;
+			}
 			default: {
 				const inline = renderInline(node.content ?? []);
 				if (inline.trim() !== '') {

--- a/packages/web/src/locales/en.json
+++ b/packages/web/src/locales/en.json
@@ -236,6 +236,7 @@
   "editor_image_insert_link_submit": "Insert Link",
   "editor_image_insert_current_target": "Default upload target: {target}",
   "editor_image_insert_upload_failed": "Image upload failed",
+  "editor_image_file_too_large": "Image is too large",
   "editor_image_replace_success": "Image replaced",
   "editor_image_replace_failed": "Failed to replace image",
   "editor_topbar_image_target_settings": "Document Settings",

--- a/packages/web/src/locales/zh.json
+++ b/packages/web/src/locales/zh.json
@@ -236,6 +236,7 @@
   "editor_image_insert_link_submit": "插入链接",
   "editor_image_insert_current_target": "当前默认上传目标：{target}",
   "editor_image_insert_upload_failed": "上传图片失败",
+  "editor_image_file_too_large": "图片过大",
   "editor_image_replace_success": "图片替换完成",
   "editor_image_replace_failed": "替换图片失败",
   "editor_topbar_image_target_settings": "文档设置",

--- a/packages/web/src/routes/edit/documents/[id]/+page.svelte
+++ b/packages/web/src/routes/edit/documents/[id]/+page.svelte
@@ -1028,24 +1028,22 @@
 						<p>{m.edit_document_editor_under_construction()}</p>
 					</div>
 				{:else}
-					{#key collaboration?.doc ? `collab:${documentId}` : `local:${documentId}`}
-						<Editor
-							documentId={documentId!}
-							{content}
-							currentImageTargetId={preferredImageTargetId}
-							currentImageTargetLabel={currentImageTargetLabel}
-							imageTargetOptions={availableImageTargets}
-							{collaboration}
-							{isUpdatingImageTarget}
-							{isSaving}
-							{hasUnsavedChanges}
-							onImageTargetChange={handleImageTargetChange}
-							hydrateManagedContent={refreshSignedImageSources}
-							onSave={saveContent}
-							onExportAction={handleExportAction}
-							onContentChange={handleContentChange}
-						/>
-					{/key}
+					<Editor
+						documentId={documentId!}
+						{content}
+						currentImageTargetId={preferredImageTargetId}
+						currentImageTargetLabel={currentImageTargetLabel}
+						imageTargetOptions={availableImageTargets}
+						{collaboration}
+						{isUpdatingImageTarget}
+						{isSaving}
+						{hasUnsavedChanges}
+						onImageTargetChange={handleImageTargetChange}
+						hydrateManagedContent={refreshSignedImageSources}
+						onSave={saveContent}
+						onExportAction={handleExportAction}
+						onContentChange={handleContentChange}
+					/>
 				{/if}
 			{:else}
 				<div class="prose dark:prose-invert">


### PR DESCRIPTION
- Add explicit image node handling in Markdown/BBCode export to include external images (previously skipped as block nodes)
- Remove {#key} block from Editor to prevent forced rebuilds when switching collaboration modes
- Add $effect to dynamically handle collaboration changes while preserving editor state and content