### PR TITLE
fix: avoid editor refresh on collaboration connect

### DIFF
--- a/packages/web/src/lib/utils/yjsProvider.ts
+++ b/packages/web/src/lib/utils/yjsProvider.ts
@@ -25,7 +25,6 @@ interface ProviderInstance {
 
 class YjsProviderManager {
 	private instances = new Map<string, ProviderInstance>();
-	private readonly CONNECTION_TIMEOUT = 10000;
 
 	async createProvider(config: ProviderConfig): Promise<ProviderInstance> {
 		const docId = config.documentId;
@@ -94,7 +93,6 @@ class YjsProviderManager {
 				instance.isConnected = false;
 				console.error(`[Yjs] Websocket connect failed for ${docId}: ${errorMsg}`);
 			});
-			await this.waitForConnection(provider, this.CONNECTION_TIMEOUT);
 
 			return instance;
 		} catch (error) {
@@ -123,42 +121,6 @@ class YjsProviderManager {
 			this.instances.set(docId, instance);
 			return instance;
 		}
-	}
-
-	private async waitForConnection(provider: HocuspocusProvider, timeout: number): Promise<void> {
-		if (provider.configuration.websocketProvider.status === 'connected') {
-			return;
-		}
-
-		return new Promise((resolve, reject) => {
-			const timer = setTimeout(() => {
-				cleanup();
-				console.warn(`[Yjs] Websocket timed out for ${provider.configuration.name}`);
-				reject(new Error('WebSocket connection timeout'));
-			}, timeout);
-
-			const handleStatus = ({ status }: { status: string }) => {
-				if (status === 'connected') {
-					cleanup();
-					resolve();
-				}
-			};
-
-			const handleAuthenticationFailed = ({ reason }: { reason: string }) => {
-				cleanup();
-				console.warn(`[Yjs] Authentication rejected for ${provider.configuration.name}: ${reason}`);
-				reject(new Error(reason || 'Authentication failed'));
-			};
-
-			const cleanup = () => {
-				clearTimeout(timer);
-				provider.off('status', handleStatus);
-				provider.off('authenticationFailed', handleAuthenticationFailed);
-			};
-
-			provider.on('status', handleStatus);
-			provider.on('authenticationFailed', handleAuthenticationFailed);
-		});
 	}
 
 	private buildWebSocketUrl(baseUrl: string): string {

--- a/packages/web/src/routes/edit/documents/[id]/+page.svelte
+++ b/packages/web/src/routes/edit/documents/[id]/+page.svelte
@@ -881,6 +881,8 @@
 					}
 					collaboration = null;
 					updateCollaborationIndicator();
+
+					await startCollaboration(documentId, 'presence');
 					console.log('[Load] Title loaded:', title);
 					isLoading = false;
 
@@ -889,7 +891,6 @@
 							presenceCount = await fetchCollaborationPresence(documentId);
 							updateCollaborationIndicator();
 							await connectPresenceSocket(documentId);
-							await startCollaboration(documentId, 'presence');
 						} catch (presenceError) {
 							console.error('[Collaboration] Failed to fetch presence:', presenceError);
 							presenceCount = 0;


### PR DESCRIPTION
This pull request simplifies the connection logic for collaborative editing by removing the connection timeout mechanism from the Yjs provider manager and updating how collaboration is started in the document editing route. These changes streamline the connection process and remove redundant or potentially problematic timeout handling.

**Yjs Provider Connection Logic Simplification:**

* Removed the `CONNECTION_TIMEOUT` constant and the `waitForConnection` method from the `YjsProviderManager` class in `yjsProvider.ts`, eliminating the explicit connection timeout and related event handling. [[1]](diffhunk://#diff-7d3f96895e903f9e2a96735392efc4003aed39c4fa6b9cf1d69071bfaedf990dL28) [[2]](diffhunk://#diff-7d3f96895e903f9e2a96735392efc4003aed39c4fa6b9cf1d69071bfaedf990dL97) [[3]](diffhunk://#diff-7d3f96895e903f9e2a96735392efc4003aed39c4fa6b9cf1d69071bfaedf990dL128-L163)

**Collaboration Flow Updates:**

* In `+page.svelte`, moved the call to `startCollaboration(documentId, 'presence')` to always occur after resetting the collaboration state, ensuring collaboration is reliably started after the document title is loaded. ([packages/web/src/routes/edit/documents/[id]/+page.svelteR884-R885](diffhunk://#diff-1b2f8a9c69a142fd02d84f60a97ab312b3e55864f3eefbbc98e3f2ad266feeb5R884-R885))
* Removed a redundant call to `startCollaboration(documentId, 'presence')` that previously occurred after connecting the presence socket, preventing duplicate initialization. ([packages/web/src/routes/edit/documents/[id]/+page.svelteL892](diffhunk://#diff-1b2f8a9c69a142fd02d84f60a97ab312b3e55864f3eefbbc98e3f2ad266feeb5L892))