### PR TITLE
修复(P0): 移除 JWT 默认密钥后门并加固 SQLite 配置

### DIFF
--- a/packages/server/cmd/server/main.go
+++ b/packages/server/cmd/server/main.go
@@ -22,6 +22,13 @@ import (
 func main() {
 	_ = config.LoadDotEnv(".env")
 
+	// Validate critical secrets BEFORE touching the database. If JWT_SECRET_KEY
+	// is missing, weak, or set to a known insecure default, refuse to start so
+	// the operator notices instead of silently shipping forgeable tokens.
+	if _, err := auth.LoadJWTSecret(); err != nil {
+		log.Fatalf("Auth configuration invalid: %v", err)
+	}
+
 	// Initialize database
 	database.Connect()
 	log.Println("Database initialization complete.")

--- a/packages/server/internal/auth/handler_test.go
+++ b/packages/server/internal/auth/handler_test.go
@@ -21,6 +21,10 @@ import (
 
 func setupAuthTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
+	// LoadJWTSecret enforces a minimum length and rejects known defaults; this
+	// value is long enough and not on the blocklist so the auth handlers can
+	// construct a TokenService without touching the operator-facing env.
+	t.Setenv("JWT_SECRET_KEY", "test-secret-please-rotate-aaaaaaaaaaaaaaaa")
 	dsn := "file:" + uuid.NewString() + "?mode=memory&cache=shared"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	if err != nil {

--- a/packages/server/internal/auth/secret.go
+++ b/packages/server/internal/auth/secret.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// minJWTSecretLength is the minimum length we accept for JWT_SECRET_KEY. 32 bytes
+// of entropy roughly matches the security margin of HS256 itself; anything shorter
+// makes brute force on weak secrets feasible.
+const minJWTSecretLength = 32
+
+// jwtSecretBlocklist contains values that have appeared in this repo (or its
+// .env.example) at some point and would render the system trivially exploitable
+// if used in production. Reject them even when explicitly set.
+var jwtSecretBlocklist = map[string]struct{}{
+	"insecure-default-secret-for-dev-only": {},
+	"replace-with-a-strong-secret":         {},
+	"change-me":                            {},
+	"changeme":                             {},
+	"secret":                               {},
+}
+
+// LoadJWTSecret reads JWT_SECRET_KEY from the environment, validates it, and
+// returns the bytes used to sign and verify access tokens. It is the single
+// source of truth for the JWT signing key — both auth.NewTokenService and the
+// middleware key function call this so that there is no way for the two halves
+// of the auth system to drift apart and accept different secrets.
+//
+// LoadJWTSecret intentionally does not cache. Reading an env var plus a few
+// string operations costs nothing compared to the HMAC verification that
+// follows, and skipping the cache means tests using t.Setenv work without
+// extra reset hooks.
+func LoadJWTSecret() ([]byte, error) {
+	raw := strings.TrimSpace(os.Getenv("JWT_SECRET_KEY"))
+	if raw == "" {
+		return nil, errors.New("JWT_SECRET_KEY environment variable is required and must not be empty")
+	}
+	// Check the blocklist before the length check so an operator who copy-pastes
+	// a known-bad default sees a clear "this value is insecure" message instead
+	// of a generic "too short" hint that they might fix by appending characters.
+	if _, blocked := jwtSecretBlocklist[strings.ToLower(raw)]; blocked {
+		return nil, errors.New("JWT_SECRET_KEY is set to a known insecure default; generate a strong random secret with `openssl rand -hex 32`")
+	}
+	if len(raw) < minJWTSecretLength {
+		return nil, fmt.Errorf("JWT_SECRET_KEY must be at least %d characters long (got %d); generate one with `openssl rand -hex 32`", minJWTSecretLength, len(raw))
+	}
+	return []byte(raw), nil
+}

--- a/packages/server/internal/auth/secret_test.go
+++ b/packages/server/internal/auth/secret_test.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadJWTSecret_RejectsMissing(t *testing.T) {
+	t.Setenv("JWT_SECRET_KEY", "")
+
+	_, err := LoadJWTSecret()
+	if err == nil {
+		t.Fatal("expected error when JWT_SECRET_KEY is unset")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Fatalf("expected required-secret error, got %v", err)
+	}
+}
+
+func TestLoadJWTSecret_RejectsWhitespaceOnly(t *testing.T) {
+	t.Setenv("JWT_SECRET_KEY", "   \t  ")
+
+	if _, err := LoadJWTSecret(); err == nil {
+		t.Fatal("expected error when JWT_SECRET_KEY is whitespace only")
+	}
+}
+
+func TestLoadJWTSecret_RejectsTooShort(t *testing.T) {
+	t.Setenv("JWT_SECRET_KEY", "short-secret")
+
+	_, err := LoadJWTSecret()
+	if err == nil {
+		t.Fatal("expected error when JWT_SECRET_KEY is too short")
+	}
+	if !strings.Contains(err.Error(), "at least") {
+		t.Fatalf("expected length error, got %v", err)
+	}
+}
+
+func TestLoadJWTSecret_RejectsKnownDefaults(t *testing.T) {
+	cases := []string{
+		"insecure-default-secret-for-dev-only",
+		"replace-with-a-strong-secret",
+		"change-me",
+		"changeme",
+		"INSECURE-DEFAULT-SECRET-FOR-DEV-ONLY", // case-insensitive
+	}
+	for _, value := range cases {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("JWT_SECRET_KEY", value)
+			_, err := LoadJWTSecret()
+			if err == nil {
+				t.Fatalf("expected blocked default error for %q", value)
+			}
+			if !strings.Contains(err.Error(), "insecure default") {
+				t.Fatalf("expected blocklist error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadJWTSecret_AcceptsStrongSecret(t *testing.T) {
+	const strong = "f3a4d6e7c1b2a8d9e0f1a2b3c4d5e6f70a1b2c3d"
+	t.Setenv("JWT_SECRET_KEY", strong)
+
+	secret, err := LoadJWTSecret()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(secret) != strong {
+		t.Fatalf("expected secret to round-trip, got %q", string(secret))
+	}
+}
+
+func TestLoadJWTSecret_TrimsSurroundingWhitespace(t *testing.T) {
+	const strong = "f3a4d6e7c1b2a8d9e0f1a2b3c4d5e6f70a1b2c3d"
+	t.Setenv("JWT_SECRET_KEY", "  "+strong+"\n")
+
+	secret, err := LoadJWTSecret()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(secret) != strong {
+		t.Fatalf("expected trimmed secret, got %q", string(secret))
+	}
+}

--- a/packages/server/internal/auth/token.go
+++ b/packages/server/internal/auth/token.go
@@ -45,14 +45,12 @@ type SessionInfo struct {
 }
 
 // NewTokenService creates a new token service, reading configuration from environment variables.
+// JWT_SECRET_KEY is required and validated by LoadJWTSecret; there is no fallback to a hardcoded
+// default. Callers should treat any error returned here as a fatal configuration error.
 func NewTokenService() (*TokenService, error) {
-	secret := os.Getenv("JWT_SECRET_KEY")
-	if secret == "" {
-		// For development, we can use a default insecure key.
-		// In production, this should cause a fatal error.
-		// For this project, we'll allow a default for ease of setup.
-		secret = "insecure-default-secret-for-dev-only"
-		fmt.Println("WARNING: JWT_SECRET_KEY not set, using insecure default key. DO NOT use in production.")
+	secret, err := LoadJWTSecret()
+	if err != nil {
+		return nil, err
 	}
 
 	accessTokenLifetimeMinutes, err := strconv.Atoi(os.Getenv("ACCESS_TOKEN_LIFETIME_MINUTES"))
@@ -66,7 +64,7 @@ func NewTokenService() (*TokenService, error) {
 	}
 
 	return &TokenService{
-		jwtSecret:              []byte(secret),
+		jwtSecret:              secret,
 		accessTokenLifetime:    time.Duration(accessTokenLifetimeMinutes) * time.Minute,
 		refreshTokenLifetime:   time.Duration(refreshTokenLifetimeHours) * time.Hour,
 		refreshTokenByteLength: 32,

--- a/packages/server/internal/database/database.go
+++ b/packages/server/internal/database/database.go
@@ -39,13 +39,53 @@ func Connect() {
 	if err := os.MkdirAll(dbPath, os.ModePerm); err != nil {
 		log.Fatalf("Failed to create database directory: %v", err)
 	}
-	dsn := filepath.Join(dbPath, "cyimewrite.db")
+	// SQLite DSN with safe defaults:
+	//   _journal_mode=WAL       — readers don't block writers and vice versa.
+	//   _busy_timeout=5000      — wait up to 5s on locked db before SQLITE_BUSY.
+	//   _foreign_keys=1         — enforce ON DELETE CASCADE declared in models.
+	//   _synchronous=NORMAL     — durability/perf trade-off appropriate for WAL.
+	//   _txlock=immediate       — acquire RESERVED lock on BEGIN to avoid
+	//                             SQLITE_BUSY on transaction promotion.
+	dsn := filepath.Join(dbPath, "cyimewrite.db") +
+		"?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=1&_synchronous=NORMAL&_txlock=immediate"
 
 	DB, err = gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: newLogger,
 	})
 	if err != nil {
 		log.Fatalf("Failed to connect to database: %v", err)
+	}
+
+	// SQLite serializes writers; opening multiple write connections only causes
+	// SQLITE_BUSY contention. Pin the pool to a single connection so GORM does
+	// not silently fan out under load.
+	sqlDB, err := DB.DB()
+	if err != nil {
+		log.Fatalf("Failed to access underlying *sql.DB: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+	sqlDB.SetConnMaxLifetime(0)
+
+	// Verify foreign keys are actually enabled. mattn/go-sqlite3 will silently
+	// ignore the DSN flag if compiled without the FK feature, and the rest of
+	// the schema relies on ON DELETE CASCADE for cleanup, so refuse to boot if
+	// they are off.
+	var fkEnabled int
+	if err := DB.Raw("PRAGMA foreign_keys").Scan(&fkEnabled).Error; err != nil {
+		log.Fatalf("Failed to read foreign_keys pragma: %v", err)
+	}
+	if fkEnabled != 1 {
+		log.Fatalf("SQLite foreign keys are not enabled (got %d); refusing to start", fkEnabled)
+	}
+
+	// Verify WAL is active so we don't silently fall back to rollback journal.
+	var journalMode string
+	if err := DB.Raw("PRAGMA journal_mode").Scan(&journalMode).Error; err != nil {
+		log.Fatalf("Failed to read journal_mode pragma: %v", err)
+	}
+	if journalMode != "wal" && journalMode != "WAL" {
+		log.Printf("Warning: SQLite journal_mode=%q (expected wal); concurrent reads may block writers", journalMode)
 	}
 
 	log.Println("Database connection established.")

--- a/packages/server/internal/database/database_test.go
+++ b/packages/server/internal/database/database_test.go
@@ -1,0 +1,111 @@
+package database
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"g.co1d.in/Coldin04/CyimeWrite/server/internal/models"
+	"github.com/google/uuid"
+)
+
+// TestConnect_AppliesSafeSQLitePragmas runs the production Connect path against
+// a temp HOME and verifies that the DSN actually delivered the safety options
+// we requested. mattn/go-sqlite3 silently drops unsupported pragma flags, so
+// the assertions below are the only thing that proves the fix is real.
+func TestConnect_AppliesSafeSQLitePragmas(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// os.UserHomeDir on Windows reads USERPROFILE; this test only fakes HOME.
+		t.Skip("HOME redirection skipped on windows")
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	// Connect calls log.Fatalf on failure, which would terminate the test
+	// process. Run it on the goroutine and let it raise; if anything goes
+	// wrong the assertions below catch it before the process exits.
+	Connect()
+	t.Cleanup(func() {
+		if DB != nil {
+			if sqlDB, err := DB.DB(); err == nil {
+				_ = sqlDB.Close()
+			}
+		}
+	})
+
+	if DB == nil {
+		t.Fatal("DB was not initialised")
+	}
+
+	var fk int
+	if err := DB.Raw("PRAGMA foreign_keys").Scan(&fk).Error; err != nil {
+		t.Fatalf("read foreign_keys pragma: %v", err)
+	}
+	if fk != 1 {
+		t.Fatalf("foreign_keys = %d, want 1", fk)
+	}
+
+	var journal string
+	if err := DB.Raw("PRAGMA journal_mode").Scan(&journal).Error; err != nil {
+		t.Fatalf("read journal_mode pragma: %v", err)
+	}
+	if journal != "wal" {
+		t.Fatalf("journal_mode = %q, want wal", journal)
+	}
+
+	var busy int
+	if err := DB.Raw("PRAGMA busy_timeout").Scan(&busy).Error; err != nil {
+		t.Fatalf("read busy_timeout pragma: %v", err)
+	}
+	if busy < 5000 {
+		t.Fatalf("busy_timeout = %d, want >= 5000", busy)
+	}
+}
+
+// TestConnect_CascadeDeletesUserSessions verifies that the foreign-key fix
+// actually causes the OnDelete:CASCADE declared on UserSession to fire. This
+// is the regression test for the silent-cascade-loss part of bug P0-#2.
+func TestConnect_CascadeDeletesUserSessions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME redirection skipped on windows")
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	Connect()
+	t.Cleanup(func() {
+		if DB != nil {
+			if sqlDB, err := DB.DB(); err == nil {
+				_ = sqlDB.Close()
+			}
+		}
+	})
+
+	email := "cascade@example.com"
+	user := models.User{
+		ID:    uuid.New(),
+		Email: &email,
+	}
+	if err := DB.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	session := models.UserSession{
+		ID:         uuid.New(),
+		UserID:     user.ID,
+		LastSeenAt: time.Now(),
+	}
+	if err := DB.Create(&session).Error; err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if err := DB.Unscoped().Delete(&user).Error; err != nil {
+		t.Fatalf("delete user: %v", err)
+	}
+
+	var remaining int64
+	if err := DB.Unscoped().Model(&models.UserSession{}).Where("id = ?", session.ID).Count(&remaining).Error; err != nil {
+		t.Fatalf("count remaining sessions: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("expected user session to cascade-delete, %d rows still present", remaining)
+	}
+}

--- a/packages/server/internal/middleware/auth.go
+++ b/packages/server/internal/middleware/auth.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"os"
 	"strings"
 
 	"g.co1d.in/Coldin04/CyimeWrite/server/internal/auth"
@@ -16,11 +15,10 @@ func jwtKeyFunc(token *jwt.Token) (interface{}, error) {
 			"unexpected signing method: "+token.Header["alg"].(string),
 		)
 	}
-	secret := os.Getenv("JWT_SECRET_KEY")
-	if secret == "" {
-		secret = "insecure-default-secret-for-dev-only"
-	}
-	return []byte(secret), nil
+	// Single source of truth — no inline fallback. If JWT_SECRET_KEY is missing
+	// or weak, every request fails fast with the same error the token issuer
+	// would have raised at startup.
+	return auth.LoadJWTSecret()
 }
 
 func parseJWTFromRequest(c *fiber.Ctx) (*auth.JWTClaims, error) {


### PR DESCRIPTION
修复了几个 Bug

修复(P0): 移除 JWT 默认密钥后门并加固 SQLite 配置
                                                                                                                           
  本次只动 P0 范围。两处问题都属于"上线前必须修复"级别——一个让任意人都能伪造 access token，另一个让 SQLite                 
  一上量就锁死、并且让所有 OnDelete:CASCADE 静默失效。                                                                     
                                                                                                                           
  P0-#1: 移除 JWT_SECRET_KEY 默认密钥后门                                                                                  
                                                                 
  问题                                                                                                                     
  - auth/token.go 与 middleware/auth.go 各自维护一份 fallback，未配置 JWT_SECRET_KEY 时回退到硬编码字符串
  "insecure-default-secret-for-dev-only"，任何知道这串常量的人都能伪造任意用户的 access token。                            
  - 两处 fallback 独立维护，理论上可以漂移到不同值，造成签发与验证密钥不一致。                 
                                                                                                                           
  改动                                                                      
  - 新增 internal/auth/secret.go 提供唯一的 LoadJWTSecret() 入口，统一拒绝：                                               
    - 空值 / 仅空白                                                                                                        
    - 长度低于 32 字符的弱密钥                                                                                             
    - 黑名单里的已知危险默认值（insecure-default-secret-for-dev-only、replace-with-a-strong-secret、change-me、changeme、se
  cret，大小写不敏感）                                                                                                     
  - TokenService 与中间件 jwtKeyFunc 都改为调用 LoadJWTSecret()，消除两边漂移的可能。                                      
  - cmd/server/main.go 启动期 fail-fast：先于 database.Connect() 做 auth.LoadJWTSecret() 校验，配置不达标直接              
  log.Fatalf，绝不允许带着 fallback 密钥进入生产。                                                                         
  - middleware/auth.go 同时移除了不再使用的 os 导入。                                                                      
                                                                                                                           
  P0-#2: SQLite DSN 加固 (WAL / 外键 / busy_timeout)                                                                       
                                                                                                                           
  问题                                                                                                                     
  - database/database.go 的 DSN 是裸文件路径 cyimewrite.db，导致：                                                         
    a. 没开 WAL —— 并发读写互相阻塞，立即触发 SQLITE_BUSY；                                                                
    b. _foreign_keys 默认关闭 —— 所有 OnDelete:CASCADE 静默失效，删用户后 sessions、refresh tokens 全部成为孤儿数据；
    c. 没有 _busy_timeout —— 锁冲突立即返回错误而不是重试。                                                                
                                                                                                                           
  改动                                                                                                                     
  - DSN 增加：_journal_mode=WAL + _busy_timeout=5000 + _foreign_keys=1 + _synchronous=NORMAL + _txlock=immediate。         
  - SetMaxOpenConns(1) / SetMaxIdleConns(1) 把写连接串行化，避免 GORM 默认连接池在 SQLite 上自相竞争。                     
  - 启动期通过 PRAGMA foreign_keys 校验外键是否真正生效，mattn/go-sqlite3 没编译 FK 支持时立即拒绝启动（防止 DSN
  标志被静默忽略）。                                                                                                       
  - 启动期同时校验 PRAGMA journal_mode，回退到非 WAL 时打印警告。                                                          
                                                                                                                           
  测试                                                                                                                     
                                                                            
  - 新增 internal/auth/secret_test.go：6 类用例覆盖                                                                        
    - missing 环境变量                                                      
    - whitespace-only 值                                                                                                   
    - 过短密钥                                                              
    - 黑名单里的 5 个已知默认值（含大小写）                                                                                
    - 合法强密钥                                                                                                           
    - 前后空白裁剪                                               
  - 新增 internal/database/database_test.go：                                                                              
    - TestConnect_AppliesSafeSQLitePragmas：通过真实 PRAGMA 校验 foreign_keys、journal_mode、busy_timeout 是否生效。
    - TestConnect_CascadeDeletesUserSessions：真删 User 验证 OnDelete:CASCADE 真正触发，回归 P0-#2 中静默失效的部分。      
  - internal/auth/handler_test.go 的 setupAuthTestDB 注入测试用 JWT_SECRET_KEY，否则 HandleListSessions                    
  系列测试会被新校验拦截。                                                                                                 
  - go test ./... 重跑 3 次，本次新增/修改的所有测试稳定通过。                                                             
                                                                                                                           