### PR TITLE
Require verified GitHub email for account linking

### DIFF
--- a/packages/server/internal/auth/handler.go
+++ b/packages/server/internal/auth/handler.go
@@ -578,17 +578,17 @@ func getUserProfile(ctx context.Context, provider *models.AuthProvider, oauth2Co
 				userName = ghUser.Login
 			}
 			userEmail := strings.TrimSpace(ghUser.Email)
-			if userEmail == "" {
-				fallbackEmail, err := fetchGitHubPrimaryEmail(ctx, oauth2Config, token)
-				if err != nil {
-					return nil, err
-				}
-				userEmail = fallbackEmail
+			verifiedEmail, emailVerified, err := fetchGitHubPrimaryEmail(ctx, oauth2Config, token)
+			if err != nil {
+				return nil, err
+			}
+			if verifiedEmail != "" {
+				userEmail = verifiedEmail
 			}
 			userProfile = UserProfile{
 				Subject:       fmt.Sprintf("%d", ghUser.ID),
 				Email:         userEmail,
-				EmailVerified: userEmail != "",
+				EmailVerified: emailVerified,
 				Name:          userName,
 				Picture:       ghUser.Avatar,
 			}
@@ -622,17 +622,17 @@ func getUserProfile(ctx context.Context, provider *models.AuthProvider, oauth2Co
 	return &userProfile, nil
 }
 
-func fetchGitHubPrimaryEmail(ctx context.Context, oauth2Config *oauth2.Config, token *oauth2.Token) (string, error) {
+func fetchGitHubPrimaryEmail(ctx context.Context, oauth2Config *oauth2.Config, token *oauth2.Token) (string, bool, error) {
 	client := oauth2Config.Client(ctx, token)
 	resp, err := client.Get("https://api.github.com/user/emails")
 	if err != nil {
-		return "", fmt.Errorf("无法获取 GitHub 邮箱信息: %w", err)
+		return "", false, fmt.Errorf("无法获取 GitHub 邮箱信息: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return "", fmt.Errorf("无法获取 GitHub 邮箱信息: status %d, body: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return "", false, fmt.Errorf("无法获取 GitHub 邮箱信息: status %d, body: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var emails []struct {
@@ -641,26 +641,32 @@ func fetchGitHubPrimaryEmail(ctx context.Context, oauth2Config *oauth2.Config, t
 		Verified bool   `json:"verified"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&emails); err != nil {
-		return "", fmt.Errorf("无法解析 GitHub 邮箱信息: %w", err)
+		return "", false, fmt.Errorf("无法解析 GitHub 邮箱信息: %w", err)
 	}
 
+	anyEmail := ""
 	for _, item := range emails {
-		if item.Primary && item.Verified && strings.TrimSpace(item.Email) != "" {
-			return strings.TrimSpace(item.Email), nil
+		email := strings.TrimSpace(item.Email)
+		if email == "" {
+			continue
+		}
+		if anyEmail == "" {
+			anyEmail = email
+		}
+		if item.Primary && item.Verified {
+			return email, true, nil
 		}
 	}
 	for _, item := range emails {
 		if item.Verified && strings.TrimSpace(item.Email) != "" {
-			return strings.TrimSpace(item.Email), nil
+			return strings.TrimSpace(item.Email), true, nil
 		}
 	}
-	for _, item := range emails {
-		if strings.TrimSpace(item.Email) != "" {
-			return strings.TrimSpace(item.Email), nil
-		}
+	if anyEmail != "" {
+		return anyEmail, false, nil
 	}
 
-	return "", nil
+	return "", false, nil
 }
 
 func optionalStringPtr(value string) *string {

--- a/packages/server/internal/auth/handler_test.go
+++ b/packages/server/internal/auth/handler_test.go
@@ -1,10 +1,12 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,6 +20,12 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func setupAuthTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
@@ -312,5 +320,56 @@ func TestGetUserProfile_ParsesGoogleOAuthUserInfoAsTrusted(t *testing.T) {
 	}
 	if profile.Picture != "https://example.com/avatar.png" {
 		t.Fatalf("expected picture propagated, got %q", profile.Picture)
+	}
+}
+
+func TestFetchGitHubPrimaryEmail_PrefersVerifiedAndMarksVerified(t *testing.T) {
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() != "https://api.github.com/user/emails" {
+				t.Fatalf("unexpected URL: %s", req.URL.String())
+			}
+			body := `[{"email":"unverified@example.com","primary":true,"verified":false},{"email":"verified@example.com","primary":false,"verified":true}]`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(body)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	})
+
+	email, verified, err := fetchGitHubPrimaryEmail(ctx, &oauth2.Config{}, &oauth2.Token{AccessToken: "token"})
+	if err != nil {
+		t.Fatalf("fetch github primary email: %v", err)
+	}
+	if email != "verified@example.com" {
+		t.Fatalf("expected verified email, got %q", email)
+	}
+	if !verified {
+		t.Fatalf("expected email to be marked verified")
+	}
+}
+
+func TestFetchGitHubPrimaryEmail_ReturnsUnverifiedWhenNoVerifiedExists(t *testing.T) {
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body := `[{"email":"only-unverified@example.com","primary":true,"verified":false}]`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(body)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	})
+
+	email, verified, err := fetchGitHubPrimaryEmail(ctx, &oauth2.Config{}, &oauth2.Token{AccessToken: "token"})
+	if err != nil {
+		t.Fatalf("fetch github primary email: %v", err)
+	}
+	if email != "only-unverified@example.com" {
+		t.Fatalf("expected fallback email, got %q", email)
+	}
+	if verified {
+		t.Fatalf("expected fallback email to be marked unverified")
 	}
 }


### PR DESCRIPTION
### Motivation
- Close a high-severity account takeover vector where GitHub OAuth logins could merge into existing users by treating any returned GitHub email string as verified, allowing unverified GitHub emails to link to victim accounts.

### Description
- Updated the GitHub OAuth path in `packages/server/internal/auth/handler.go` so `getUserProfile` consumes both email value and verification state from `fetchGitHubPrimaryEmail` and sets `UserProfile.EmailVerified` from that boolean rather than `email != ""`.
- Changed `fetchGitHubPrimaryEmail` to return `(string, bool, error)` and implemented selection logic that prefers primary+verified, then any verified, and only returns an unverified fallback email while marking it unverified.
- Added targeted tests and a lightweight HTTP client helper in `packages/server/internal/auth/handler_test.go` to cover verified-email preference and the unverified fallback behavior for GitHub email fetching.
- Preserved existing fallback behavior of returning an email for display/storage when no verified address exists while preventing unsafe auto-link merges by marking such fallbacks as unverified.

### Testing
- Ran `go test ./internal/auth -run TestFetchGitHubPrimaryEmail` and the new GitHub-email tests passed.
- Ran the full `go test ./internal/auth` and observed an unrelated pre-existing test `TestGetUserProfile_ParsesGoogleOAuthUserInfoAsTrusted` failing, which is not caused by the GitHub-specific changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d8f1d0f9a483219f1f04b90019b30a)