### PR TITLE
fix(web): prevent stored XSS via unsafe pasted image sources

### DIFF
--- a/packages/web/src/lib/components/editor/Editor.svelte
+++ b/packages/web/src/lib/components/editor/Editor.svelte
@@ -183,12 +183,35 @@
 	function sanitizePastedHTML(html: string): string {
 		const parser = new DOMParser();
 		const doc = parser.parseFromString(html, 'text/html');
+		const allowedDataImageMimeTypes = new Set([
+			'image/png',
+			'image/jpeg',
+			'image/webp',
+			'image/gif'
+		]);
+
+		const isAllowedImageSrc = (src: string): boolean => {
+			const value = src.trim();
+			if (!value) return false;
+
+			if (value.startsWith('data:')) {
+				const mimeType = value.slice(5).split(';', 1)[0]?.toLowerCase() ?? '';
+				return allowedDataImageMimeTypes.has(mimeType);
+			}
+
+			try {
+				const parsed = new URL(value, window.location.origin);
+				return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+			} catch {
+				return false;
+			}
+		};
 
 		doc.querySelectorAll('script, style, meta, link').forEach((node) => node.remove());
 
 		doc.querySelectorAll('img').forEach((img) => {
 			const src = img.getAttribute('src')?.trim();
-			if (!src) {
+			if (!src || !isAllowedImageSrc(src)) {
 				img.remove();
 				return;
 			}
@@ -201,6 +224,7 @@
 					attrName === 'style' ||
 					attrName === 'class' ||
 					attrName === 'id' ||
+					attrName.startsWith('on') ||
 					attrName.startsWith('data-') ||
 					attrName.startsWith('aria-');
 				if (isUnsafe) {


### PR DESCRIPTION
### Motivation
- Prevent stored XSS introduced by the markdown paste flow where `marked` output could produce `<img src="data:image/svg+xml,...">` and be persisted and executed when documents are viewed.
- Harden the editor paste sanitizer so only safe image sources and attributes are allowed when converting pasted markdown/HTML into editor content.

### Description
- Updated `packages/web/src/lib/components/editor/Editor.svelte` to add `allowedDataImageMimeTypes` and an `isAllowedImageSrc` helper that validates `img` `src` values.
- The sanitizer now removes `<img>` elements whose `src` is empty, not an `http:`/`https:` URL, or a `data:` URI with a disallowed MIME type (only `image/png`, `image/jpeg`, `image/webp`, `image/gif` are allowed).
- Stripped inline event handler attributes by removing attributes that start with `on` from pasted elements in addition to the existing removals of `style`, `class`, `id`, `data-*`, and `aria-*`.
- Kept existing removals of `script`, `style`, `meta`, and `link` nodes and the span-flattening behavior to retain structure while reducing noisy wrappers.

### Testing
- Ran the production build with `pnpm -C packages/web run build`, which completed successfully (build warnings unrelated to this change were present but did not block the build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d8fb56b8cc8321a2913f2fc08fb941)