### PR TITLE
Enforce document quota for soft-deleted items

### DIFF
--- a/packages/server/internal/workspace/service.go
+++ b/packages/server/internal/workspace/service.go
@@ -63,6 +63,29 @@ func resolveDocumentPreferredImageTargetID(value string) string {
 	return LegacyPreferredImageTargetID
 }
 
+func ensureDocumentQuotaWithinLimit(tx *gorm.DB, userID uuid.UUID, additionalDocuments int64) error {
+	limit, err := user.GetEffectiveDocumentQuotaWithDB(tx, userID)
+	if err != nil {
+		return err
+	}
+	if limit == nil {
+		return nil
+	}
+
+	var totalCount int64
+	if err := tx.Unscoped().Model(&models.Document{}).
+		Where("owner_user_id = ?", userID).
+		Count(&totalCount).Error; err != nil {
+		return err
+	}
+
+	if totalCount+additionalDocuments > int64(*limit) {
+		return ErrDocumentQuotaExceeded
+	}
+
+	return nil
+}
+
 func resolveUsableImageTargetForUser(userID uuid.UUID, preferredImageTargetID string) (string, error) {
 	normalized := normalizePreferredImageTargetID(preferredImageTargetID)
 	if normalized == "" || normalized == DefaultPreferredImageTargetID {
@@ -787,20 +810,8 @@ func CreateDocument(userID uuid.UUID, title string, contentJSON string, folderID
 	// Create the document in a transaction
 	var document *models.Document
 	err := database.DB.Transaction(func(tx *gorm.DB) error {
-		limit, err := user.GetEffectiveDocumentQuotaWithDB(tx, userID)
-		if err != nil {
+		if err := ensureDocumentQuotaWithinLimit(tx, userID, 1); err != nil {
 			return err
-		}
-		if limit != nil {
-			var activeCount int64
-			if err := tx.Model(&models.Document{}).
-				Where("owner_user_id = ? AND deleted_at IS NULL", userID).
-				Count(&activeCount).Error; err != nil {
-				return err
-			}
-			if activeCount >= int64(*limit) {
-				return ErrDocumentQuotaExceeded
-			}
 		}
 
 		// Create document metadata
@@ -1791,6 +1802,14 @@ func RestoreTrashedItems(userID uuid.UUID, itemsToRestore []ItemToRestore) (*Res
 	err := database.DB.Transaction(func(tx *gorm.DB) error {
 		for _, item := range itemsToRestore {
 			if item.Type == "folder" {
+				if err := ensureDocumentQuotaWithinLimit(tx, userID, 0); err != nil {
+					if errors.Is(err, ErrDocumentQuotaExceeded) {
+						failedItems = append(failedItems, FailedItem{ID: item.ID, Type: item.Type, Reason: err.Error()})
+						continue
+					}
+					return err
+				}
+
 				var folder models.Folder
 				// Find the folder, including soft-deleted ones
 				if err := tx.Unscoped().Where("id = ? AND owner_user_id = ?", item.ID, userID).First(&folder).Error; err != nil {
@@ -1812,6 +1831,14 @@ func RestoreTrashedItems(userID uuid.UUID, itemsToRestore []ItemToRestore) (*Res
 				}
 				restoredCount++
 			} else if item.Type == "document" {
+				if err := ensureDocumentQuotaWithinLimit(tx, userID, 0); err != nil {
+					if errors.Is(err, ErrDocumentQuotaExceeded) {
+						failedItems = append(failedItems, FailedItem{ID: item.ID, Type: item.Type, Reason: err.Error()})
+						continue
+					}
+					return err
+				}
+
 				document, err := acl.CanAccessDocumentOwnerOnlyUnscoped(tx, userID, item.ID)
 				if err != nil {
 					failedItems = append(failedItems, FailedItem{ID: item.ID, Type: item.Type, Reason: "项目不存在。"})

--- a/packages/server/internal/workspace/service.go
+++ b/packages/server/internal/workspace/service.go
@@ -1800,14 +1800,20 @@ func RestoreTrashedItems(userID uuid.UUID, itemsToRestore []ItemToRestore) (*Res
 	var failedItems []FailedItem
 
 	err := database.DB.Transaction(func(tx *gorm.DB) error {
+		restoreBlockedByQuota := false
+		if err := ensureDocumentQuotaWithinLimit(tx, userID, 0); err != nil {
+			if errors.Is(err, ErrDocumentQuotaExceeded) {
+				restoreBlockedByQuota = true
+			} else {
+				return err
+			}
+		}
+
 		for _, item := range itemsToRestore {
 			if item.Type == "folder" {
-				if err := ensureDocumentQuotaWithinLimit(tx, userID, 0); err != nil {
-					if errors.Is(err, ErrDocumentQuotaExceeded) {
-						failedItems = append(failedItems, FailedItem{ID: item.ID, Type: item.Type, Reason: err.Error()})
-						continue
-					}
-					return err
+				if restoreBlockedByQuota {
+					failedItems = append(failedItems, FailedItem{ID: item.ID, Type: item.Type, Reason: ErrDocumentQuotaExceeded.Error()})
+					continue
 				}
 
 				var folder models.Folder
@@ -1831,12 +1837,9 @@ func RestoreTrashedItems(userID uuid.UUID, itemsToRestore []ItemToRestore) (*Res
 				}
 				restoredCount++
 			} else if item.Type == "document" {
-				if err := ensureDocumentQuotaWithinLimit(tx, userID, 0); err != nil {
-					if errors.Is(err, ErrDocumentQuotaExceeded) {
-						failedItems = append(failedItems, FailedItem{ID: item.ID, Type: item.Type, Reason: err.Error()})
-						continue
-					}
-					return err
+				if restoreBlockedByQuota {
+					failedItems = append(failedItems, FailedItem{ID: item.ID, Type: item.Type, Reason: ErrDocumentQuotaExceeded.Error()})
+					continue
 				}
 
 				document, err := acl.CanAccessDocumentOwnerOnlyUnscoped(tx, userID, item.ID)

--- a/packages/server/internal/workspace/service_security_test.go
+++ b/packages/server/internal/workspace/service_security_test.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -618,6 +619,74 @@ func TestLeaveSharedDocument_RemovesPermissionOnly(t *testing.T) {
 	}
 	if doc.DeletedAt.Valid {
 		t.Fatalf("expected document untouched")
+	}
+}
+
+func TestCreateDocument_CountsTrashedDocumentsTowardQuota(t *testing.T) {
+	db := setupWorkspaceTestDB(t)
+	ownerID := uuid.New()
+	docID := seedDocumentForWorkspace(t, db, ownerID, "trashed-doc")
+
+	quota := 1
+	if err := db.Model(&models.User{}).Where("id = ?", ownerID).Update("document_quota", quota).Error; err != nil {
+		t.Fatalf("set document quota: %v", err)
+	}
+	if err := db.Delete(&models.Document{}, "id = ?", docID).Error; err != nil {
+		t.Fatalf("trash document: %v", err)
+	}
+	if err := db.Delete(&models.DocumentBody{}, "document_id = ?", docID).Error; err != nil {
+		t.Fatalf("trash document body: %v", err)
+	}
+
+	_, err := CreateDocument(
+		ownerID,
+		"new-doc",
+		`{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"new"}]}]}`,
+		nil,
+		"rich_text",
+		"",
+	)
+	if !errors.Is(err, ErrDocumentQuotaExceeded) {
+		t.Fatalf("expected document quota exceeded, got %v", err)
+	}
+}
+
+func TestRestoreTrashedItems_RejectsWhenQuotaAlreadyExceeded(t *testing.T) {
+	db := setupWorkspaceTestDB(t)
+	ownerID := uuid.New()
+	docID := seedDocumentForWorkspace(t, db, ownerID, "trashed-doc")
+
+	quota := 0
+	if err := db.Model(&models.User{}).Where("id = ?", ownerID).Update("document_quota", quota).Error; err != nil {
+		t.Fatalf("set document quota: %v", err)
+	}
+	if err := db.Delete(&models.Document{}, "id = ?", docID).Error; err != nil {
+		t.Fatalf("trash document: %v", err)
+	}
+	if err := db.Delete(&models.DocumentBody{}, "document_id = ?", docID).Error; err != nil {
+		t.Fatalf("trash document body: %v", err)
+	}
+
+	response, err := RestoreTrashedItems(ownerID, []ItemToRestore{{ID: docID, Type: "document"}})
+	if err != nil {
+		t.Fatalf("restore trashed items: %v", err)
+	}
+	if response.RestoredCount != 0 {
+		t.Fatalf("expected zero restored items, got %d", response.RestoredCount)
+	}
+	if len(response.FailedItems) != 1 {
+		t.Fatalf("expected one failed item, got %+v", response.FailedItems)
+	}
+	if response.FailedItems[0].Reason != ErrDocumentQuotaExceeded.Error() {
+		t.Fatalf("expected quota failure, got %+v", response.FailedItems[0])
+	}
+
+	var document models.Document
+	if err := db.Unscoped().First(&document, "id = ?", docID).Error; err != nil {
+		t.Fatalf("load trashed document: %v", err)
+	}
+	if !document.DeletedAt.Valid {
+		t.Fatal("expected document to remain in trash")
 	}
 }
 


### PR DESCRIPTION
This pull request refactors how document quotas are enforced and counted in the workspace service. The main improvement is that trashed documents now count toward a user's document quota, preventing users from exceeding their quota by trashing documents. The logic for quota enforcement is centralized, and comprehensive tests are added to ensure correctness.

**Document Quota Enforcement Improvements:**

* Added a new helper function `ensureDocumentQuotaWithinLimit` to centralize and standardize quota checks, ensuring both active and trashed documents are counted toward the quota.
* Updated `CreateDocument` to use the new quota enforcement logic, so creating a new document fails if the total (including trashed) exceeds the quota.

**Restore Behavior and Error Handling:**

* Updated `RestoreTrashedItems` to check quotas before restoring folders or documents, and to fail gracefully with a clear error if the quota would be exceeded, leaving items in the trash. [[1]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9R1805-R1812) [[2]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9R1834-R1841)

**Testing:**

* Added tests to ensure that trashed documents are counted toward the quota and that restoring trashed items fails if the quota is already exceeded. These tests verify the new behavior and error handling.

**Other:**

* Added the `errors` package import to support improved error handling in tests.Add ensureDocumentQuotaWithinLimit helper and use it in CreateDocument and RestoreTrashedItems so soft-deleted documents count toward a user's document quota. Add tests for create and restore scenarios.