### PR TITLE
Show combined active and trashed doc count

### DIFF
--- a/packages/web/src/lib/components/user/OverviewTab.svelte
+++ b/packages/web/src/lib/components/user/OverviewTab.svelte
@@ -27,6 +27,10 @@
 		if (unlimited || limit === null) return m.user_overview_unlimited();
 		return String(limit);
 	}
+
+	function getUsedDocumentCount(overview: UserOverview): number {
+		return overview.activeDocumentCount + overview.trashedDocumentCount;
+	}
 </script>
 
 <div class="space-y-4">
@@ -60,7 +64,7 @@
 						{m.user_overview_limit_unlimited_hint()}
 					{:else}
 						{m.user_overview_limit_usage({
-							count: String(overview.activeDocumentCount),
+							count: String(getUsedDocumentCount(overview)),
 							limit: String(overview.documentLimit ?? 0)
 						})}
 					{/if}


### PR DESCRIPTION
This pull request makes a minor improvement to the `OverviewTab.svelte` component by updating how the document usage count is calculated and displayed. Instead of showing only the count of active documents, the UI now displays the total of both active and trashed documents against the user's document limit.

- User document usage calculation:
  * Added a new function `getUsedDocumentCount` to sum `activeDocumentCount` and `trashedDocumentCount` for a more accurate usage display.
  * Updated the usage display to use the combined count instead of just the active document count.