### PR TITLE
fix:Enhance workspace search and media matching functionality

### DIFF
--- a/packages/server/internal/workspace/search_test.go
+++ b/packages/server/internal/workspace/search_test.go
@@ -178,3 +178,59 @@ func TestSearchWorkspace_MultiKeywordMediaMatchesAcrossTerms(t *testing.T) {
 		t.Fatalf("expected multi-keyword media hit, got %+v", result.Media)
 	}
 }
+
+func TestSearchWorkspace_FuzzyAndRankedResults(t *testing.T) {
+	db := setupWorkspaceTestDB(t)
+	userID := uuid.New()
+
+	topDocID := seedDocumentForWorkspace(t, db, userID, "挂载指南")
+	_ = seedDocumentForWorkspace(t, db, userID, "云端挂载实践记录")
+
+	folderA := models.Folder{
+		ID:          uuid.New(),
+		OwnerUserID: userID,
+		Name:        "挂载资料",
+		CreatedBy:   userID,
+		UpdatedBy:   userID,
+	}
+	folderB := models.Folder{
+		ID:          uuid.New(),
+		OwnerUserID: userID,
+		Name:        "我的挂载备忘",
+		CreatedBy:   userID,
+		UpdatedBy:   userID,
+	}
+	if err := db.Create(&folderA).Error; err != nil {
+		t.Fatalf("create folderA: %v", err)
+	}
+	if err := db.Create(&folderB).Error; err != nil {
+		t.Fatalf("create folderB: %v", err)
+	}
+
+	seedWorkspaceAsset(t, db, userID, topDocID, "挂载说明.png")
+
+	result, err := SearchWorkspace(userID, "挂南", 5)
+	if err != nil {
+		t.Fatalf("search workspace: %v", err)
+	}
+
+	if len(result.Documents) == 0 || result.Documents[0].ID != topDocID {
+		t.Fatalf("expected fuzzy title match to rank first, got %+v", result.Documents)
+	}
+
+	result, err = SearchWorkspace(userID, "挂资", 5)
+	if err != nil {
+		t.Fatalf("search workspace folders: %v", err)
+	}
+	if len(result.Folders) == 0 || result.Folders[0].Name != "挂载资料" {
+		t.Fatalf("expected stronger folder name match to rank first, got %+v", result.Folders)
+	}
+
+	result, err = SearchWorkspace(userID, "挂说", 5)
+	if err != nil {
+		t.Fatalf("search workspace media: %v", err)
+	}
+	if len(result.Media) == 0 || result.Media[0].Filename != "挂载说明.png" {
+		t.Fatalf("expected fuzzy media filename match, got %+v", result.Media)
+	}
+}

--- a/packages/server/internal/workspace/search_test.go
+++ b/packages/server/internal/workspace/search_test.go
@@ -159,7 +159,22 @@ func TestSearchWorkspace_MultiKeywordSnippetPrefersMatchedContext(t *testing.T) 
 	if len(result.Documents) != 1 {
 		t.Fatalf("expected single document hit, got %+v", result.Documents)
 	}
-	if !strings.Contains(result.Documents[0].Excerpt, "青柠") {
-		t.Fatalf("expected snippet to include one of the keywords, got %+v", result.Documents[0].Excerpt)
+	if !strings.Contains(result.Documents[0].Excerpt, "青柠") || !strings.Contains(result.Documents[0].Excerpt, "独特") {
+		t.Fatalf("expected snippet to include both keyword contexts, got %+v", result.Documents[0].Excerpt)
+	}
+}
+
+func TestSearchWorkspace_MultiKeywordMediaMatchesAcrossTerms(t *testing.T) {
+	db := setupWorkspaceTestDB(t)
+	userID := uuid.New()
+	docID := seedDocumentForWorkspace(t, db, userID, "青柠笔记")
+	seedWorkspaceAsset(t, db, userID, docID, "独特香气.png")
+
+	result, err := SearchWorkspace(userID, "青柠 独特", 5)
+	if err != nil {
+		t.Fatalf("search workspace: %v", err)
+	}
+	if len(result.Media) != 1 {
+		t.Fatalf("expected multi-keyword media hit, got %+v", result.Media)
 	}
 }

--- a/packages/server/internal/workspace/service.go
+++ b/packages/server/internal/workspace/service.go
@@ -493,19 +493,20 @@ func collectSearchMatches(text string, terms []string) []searchMatch {
 	matches := make([]searchMatch, 0, len(terms))
 
 	for _, term := range terms {
-		termRunes := []rune(strings.ToLower(term))
+		lowerTerm := strings.ToLower(term)
+		termRunes := []rune(lowerTerm)
 		if len(termRunes) == 0 || len(termRunes) > len(lowerTextRunes) {
 			continue
 		}
 
 		for idx := 0; idx <= len(lowerTextRunes)-len(termRunes); idx++ {
-			if string(lowerTextRunes[idx:idx+len(termRunes)]) != string(termRunes) {
+			if !slices.Equal(lowerTextRunes[idx:idx+len(termRunes)], termRunes) {
 				continue
 			}
 			matches = append(matches, searchMatch{
 				start:  idx,
 				length: len(termRunes),
-				term:   strings.ToLower(term),
+				term:   lowerTerm,
 			})
 			break
 		}
@@ -519,20 +520,6 @@ func collectSearchMatches(text string, terms []string) []searchMatch {
 	})
 
 	return matches
-}
-
-func locateSearchMatch(text string, terms []string) (start int, termLength int, ok bool) {
-	textRunes := []rune(text)
-	matches := collectSearchMatches(text, terms)
-	if len(matches) == 0 {
-		return 0, 0, false
-	}
-
-	best := matches[0]
-	if best.start > len(textRunes) {
-		return 0, 0, false
-	}
-	return best.start, best.length, true
 }
 
 func locateBestSnippetWindow(text string, terms []string, radius int) (start int, end int, ok bool) {
@@ -680,21 +667,6 @@ func normalizeSearchCandidatesLimit(limit int) int {
 	return candidateLimit
 }
 
-func matchesSearchTerms(value string, terms []string) bool {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" || len(terms) == 0 {
-		return false
-	}
-
-	lowerValue := strings.ToLower(trimmed)
-	for _, term := range terms {
-		if strings.Contains(lowerValue, strings.ToLower(term)) {
-			return true
-		}
-	}
-	return false
-}
-
 func matchTermSubsequence(value, term string) (start int, span int, gaps int, ok bool) {
 	valueRunes := []rune(strings.ToLower(value))
 	termRunes := []rune(strings.ToLower(term))
@@ -837,43 +809,6 @@ func fetchOwnedSearchFolders(userID uuid.UUID, terms []string, limit int, applyF
 	return folders, nil
 }
 
-func searchOwnedAssetsByTerms(userID uuid.UUID, terms []string, limit int) ([]media.AssetListItem, error) {
-	if len(terms) == 0 {
-		return nil, nil
-	}
-
-	queries := append([]string{strings.Join(terms, " ")}, terms...)
-	assetsByID := make(map[uuid.UUID]media.AssetListItem, limit*len(queries))
-	for _, term := range queries {
-		items, err := media.ListOwnedAssets(media.ListAssetsRequest{
-			UserID: userID,
-			Query:  term,
-			Limit:  limit,
-		})
-		if err != nil {
-			return nil, err
-		}
-		for _, item := range items.Items {
-			existing, exists := assetsByID[item.ID]
-			if !exists || item.UpdatedAt.After(existing.UpdatedAt) {
-				assetsByID[item.ID] = item
-			}
-		}
-	}
-
-	assets := make([]media.AssetListItem, 0, len(assetsByID))
-	for _, item := range assetsByID {
-		assets = append(assets, item)
-	}
-	sort.Slice(assets, func(i, j int) bool {
-		return assets[i].UpdatedAt.After(assets[j].UpdatedAt)
-	})
-	if len(assets) > limit {
-		assets = assets[:limit]
-	}
-	return assets, nil
-}
-
 func collectRecentOwnedAssets(userID uuid.UUID, limit int) ([]media.AssetListItem, error) {
 	items, err := media.ListOwnedAssets(media.ListAssetsRequest{
 		UserID: userID,
@@ -885,43 +820,6 @@ func collectRecentOwnedAssets(userID uuid.UUID, limit int) ([]media.AssetListIte
 	return items.Items, nil
 }
 
-func searchSharedAssetsByTerms(userID uuid.UUID, terms []string, limit int) ([]media.SharedAssetListItem, error) {
-	if len(terms) == 0 {
-		return nil, nil
-	}
-
-	queries := append([]string{strings.Join(terms, " ")}, terms...)
-	assetsByID := make(map[uuid.UUID]media.SharedAssetListItem, limit*len(queries))
-	for _, term := range queries {
-		items, err := media.ListSharedEditableAssets(media.ListAssetsRequest{
-			UserID: userID,
-			Query:  term,
-			Limit:  limit,
-		})
-		if err != nil {
-			return nil, err
-		}
-		for _, item := range items.Items {
-			existing, exists := assetsByID[item.ID]
-			if !exists || item.UpdatedAt.After(existing.UpdatedAt) {
-				assetsByID[item.ID] = item
-			}
-		}
-	}
-
-	assets := make([]media.SharedAssetListItem, 0, len(assetsByID))
-	for _, item := range assetsByID {
-		assets = append(assets, item)
-	}
-	sort.Slice(assets, func(i, j int) bool {
-		return assets[i].UpdatedAt.After(assets[j].UpdatedAt)
-	})
-	if len(assets) > limit {
-		assets = assets[:limit]
-	}
-	return assets, nil
-}
-
 func collectRecentSharedAssets(userID uuid.UUID, limit int) ([]media.SharedAssetListItem, error) {
 	items, err := media.ListSharedEditableAssets(media.ListAssetsRequest{
 		UserID: userID,
@@ -931,6 +829,22 @@ func collectRecentSharedAssets(userID uuid.UUID, limit int) ([]media.SharedAsset
 		return nil, err
 	}
 	return items.Items, nil
+}
+
+func chooseBestSharedAssetDocument(documents []media.SharedAssetDocument, terms []string) *media.SharedAssetDocument {
+	var best *media.SharedAssetDocument
+	bestScore := -1
+	for idx := range documents {
+		score, matched := scoreSearchValue(documents[idx].Title, terms)
+		if !matched {
+			score = 0
+		}
+		if best == nil || score > bestScore || (score == bestScore && documents[idx].UpdatedAt.After(best.UpdatedAt)) {
+			best = &documents[idx]
+			bestScore = score
+		}
+	}
+	return best
 }
 
 func applyMultiKeywordLike(query *gorm.DB, terms []string, fields []string) *gorm.DB {
@@ -1079,65 +993,15 @@ func SearchWorkspace(userID uuid.UUID, rawQuery string, limit int) (*SearchRespo
 		result.Folders = result.Folders[:limit]
 	}
 
-	ownedAssets, err := searchOwnedAssetsByTerms(userID, terms, limit)
+	ownedAssets, err := collectRecentOwnedAssets(userID, candidateLimit)
 	if err != nil {
 		return nil, err
 	}
 	sharedAssets := []media.SharedAssetListItem{}
 	if config.GetCollaborationEnabled() {
-		sharedAssets, err = searchSharedAssetsByTerms(userID, terms, limit)
+		sharedAssets, err = collectRecentSharedAssets(userID, candidateLimit)
 		if err != nil {
 			return nil, err
-		}
-	}
-
-	if len(ownedAssets)+len(sharedAssets) < limit {
-		existingOwned := make(map[uuid.UUID]struct{}, len(ownedAssets))
-		for _, item := range ownedAssets {
-			existingOwned[item.ID] = struct{}{}
-		}
-		recentOwnedAssets, err := collectRecentOwnedAssets(userID, candidateLimit)
-		if err != nil {
-			return nil, err
-		}
-		for _, item := range recentOwnedAssets {
-			if _, ok := existingOwned[item.ID]; ok {
-				continue
-			}
-			if _, matched := scoreSearchValue(item.Filename, terms); !matched {
-				continue
-			}
-			ownedAssets = append(ownedAssets, item)
-			existingOwned[item.ID] = struct{}{}
-		}
-		if config.GetCollaborationEnabled() {
-			existingShared := make(map[uuid.UUID]struct{}, len(sharedAssets))
-			for _, item := range sharedAssets {
-				existingShared[item.ID] = struct{}{}
-			}
-			recentSharedAssets, err := collectRecentSharedAssets(userID, candidateLimit)
-			if err != nil {
-				return nil, err
-			}
-			for _, item := range recentSharedAssets {
-				if _, ok := existingShared[item.ID]; ok {
-					continue
-				}
-				titleText := ""
-				if len(item.Documents) > 0 {
-					titleText = item.Documents[0].Title
-				}
-				filenameScore, filenameMatched := scoreSearchValue(item.Filename, terms)
-				titleScore, titleMatched := scoreSearchValue(titleText, terms)
-				if !filenameMatched && !titleMatched {
-					continue
-				}
-				if filenameScore == 0 && titleScore == 0 {
-					continue
-				}
-				sharedAssets = append(sharedAssets, item)
-				existingShared[item.ID] = struct{}{}
-			}
 		}
 	}
 
@@ -1186,8 +1050,8 @@ func SearchWorkspace(userID uuid.UUID, rawQuery string, limit int) (*SearchRespo
 	}
 	for _, item := range sharedAssets {
 		var documentID *uuid.UUID
-		if len(item.Documents) > 0 {
-			documentID = &item.Documents[0].DocumentID
+		if bestDocument := chooseBestSharedAssetDocument(item.Documents, terms); bestDocument != nil {
+			documentID = &bestDocument.DocumentID
 		}
 		appendMediaItem(item.ID, item.Filename, item.Kind, item.MimeType, documentID, item.UpdatedAt)
 	}

--- a/packages/server/internal/workspace/service.go
+++ b/packages/server/internal/workspace/service.go
@@ -656,6 +656,30 @@ func buildDocumentSearchSnippetFromSources(excerpt, manualExcerpt, plainText, co
 	return resolveDocumentListExcerpt(excerpt, manualExcerpt)
 }
 
+type workspaceSearchDocumentRow struct {
+	ID                     uuid.UUID
+	OwnerUserID            uuid.UUID
+	FolderID               *uuid.UUID
+	Title                  string
+	Excerpt                string
+	ManualExcerpt          string
+	PlainText              string
+	ContentJSON            string
+	DocumentType           string
+	PreferredImageTargetID string
+	PublicAccess           string
+	MyRole                 string
+	UpdatedAt              time.Time
+}
+
+func normalizeSearchCandidatesLimit(limit int) int {
+	candidateLimit := max(limit*4, 20)
+	if candidateLimit > 80 {
+		return 80
+	}
+	return candidateLimit
+}
+
 func matchesSearchTerms(value string, terms []string) bool {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" || len(terms) == 0 {
@@ -669,6 +693,148 @@ func matchesSearchTerms(value string, terms []string) bool {
 		}
 	}
 	return false
+}
+
+func matchTermSubsequence(value, term string) (start int, span int, gaps int, ok bool) {
+	valueRunes := []rune(strings.ToLower(value))
+	termRunes := []rune(strings.ToLower(term))
+	if len(valueRunes) == 0 || len(termRunes) == 0 || len(termRunes) > len(valueRunes) {
+		return 0, 0, 0, false
+	}
+
+	start = -1
+	last := -1
+	matched := 0
+	for idx, current := range valueRunes {
+		if current != termRunes[matched] {
+			continue
+		}
+		if start == -1 {
+			start = idx
+		} else if last >= 0 && idx > last+1 {
+			gaps += idx - last - 1
+		}
+		last = idx
+		matched++
+		if matched == len(termRunes) {
+			return start, last - start + 1, gaps, true
+		}
+	}
+
+	return 0, 0, 0, false
+}
+
+func scoreSearchValue(value string, terms []string) (score int, matched bool) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || len(terms) == 0 {
+		return 0, false
+	}
+
+	lowerValue := strings.ToLower(trimmed)
+	matchedTerms := 0
+	for _, term := range terms {
+		lowerTerm := strings.ToLower(term)
+		if lowerTerm == "" {
+			continue
+		}
+
+		if index := strings.Index(lowerValue, lowerTerm); index >= 0 {
+			matched = true
+			matchedTerms++
+			termScore := 1200 + len([]rune(lowerTerm))*12 - min(index, 120)*5
+			if index == 0 {
+				termScore += 220
+			}
+			if lowerValue == lowerTerm {
+				termScore += 320
+			}
+			score += max(termScore, 200)
+			continue
+		}
+
+		start, span, gaps, ok := matchTermSubsequence(lowerValue, lowerTerm)
+		if !ok {
+			continue
+		}
+		matched = true
+		matchedTerms++
+		termScore := 260 + len([]rune(lowerTerm))*8 - span*4 - gaps*6 - min(start, 120)*2
+		score += max(termScore, 40)
+	}
+
+	if !matched {
+		return 0, false
+	}
+	score += matchedTerms * 900
+	if matchedTerms == len(terms) {
+		score += 1400
+	}
+	return score, true
+}
+
+func fetchAccessibleDocumentSearchRows(userID uuid.UUID, terms []string, limit int, applyFilter bool) ([]workspaceSearchDocumentRow, error) {
+	rows := make([]workspaceSearchDocumentRow, 0)
+	selectRole := "COALESCE(perms.role, '') AS my_role"
+	documentQuery := database.DB.
+		Table("documents AS d").
+		Joins("LEFT JOIN document_bodies AS bodies ON bodies.document_id = d.id AND bodies.deleted_at IS NULL")
+	if config.GetCollaborationEnabled() {
+		documentQuery = documentQuery.
+			Joins("LEFT JOIN document_permissions AS perms ON perms.document_id = d.id AND perms.user_id = ? AND perms.deleted_at IS NULL", userID).
+			Where("(d.owner_user_id = ? OR perms.role IN ?)", userID, acl.AllowedRolesForAction(acl.ActionRead))
+	} else {
+		documentQuery = documentQuery.Where("d.owner_user_id = ?", userID)
+		selectRole = "'' AS my_role"
+	}
+	if applyFilter {
+		documentQuery = applyMultiKeywordLike(documentQuery, terms, []string{
+			"d.title",
+			"d.excerpt",
+			"d.manual_excerpt",
+			"bodies.plain_text",
+			"bodies.content_json",
+		})
+	}
+
+	err := documentQuery.
+		Where("d.deleted_at IS NULL").
+		Select(
+			"d.id",
+			"d.owner_user_id",
+			"d.folder_id",
+			"d.title",
+			"d.excerpt",
+			"d.manual_excerpt",
+			"COALESCE(bodies.plain_text, '') AS plain_text",
+			"COALESCE(bodies.content_json, '') AS content_json",
+			"d.document_type",
+			"d.preferred_image_target_id",
+			"d.public_access",
+			selectRole,
+			"d.updated_at",
+		).
+		Order("d.updated_at desc").
+		Limit(limit).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func fetchOwnedSearchFolders(userID uuid.UUID, terms []string, limit int, applyFilter bool) ([]models.Folder, error) {
+	folders := make([]models.Folder, 0)
+	query := database.DB.Where("owner_user_id = ? AND deleted_at IS NULL", userID)
+	if applyFilter {
+		query = applyMultiKeywordLike(query, terms, []string{"name"})
+	}
+	if err := query.
+		Order("updated_at desc").
+		Limit(limit).
+		Find(&folders).Error; err != nil {
+		return nil, err
+	}
+	return folders, nil
 }
 
 func searchOwnedAssetsByTerms(userID uuid.UUID, terms []string, limit int) ([]media.AssetListItem, error) {
@@ -708,6 +874,17 @@ func searchOwnedAssetsByTerms(userID uuid.UUID, terms []string, limit int) ([]me
 	return assets, nil
 }
 
+func collectRecentOwnedAssets(userID uuid.UUID, limit int) ([]media.AssetListItem, error) {
+	items, err := media.ListOwnedAssets(media.ListAssetsRequest{
+		UserID: userID,
+		Limit:  limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return items.Items, nil
+}
+
 func searchSharedAssetsByTerms(userID uuid.UUID, terms []string, limit int) ([]media.SharedAssetListItem, error) {
 	if len(terms) == 0 {
 		return nil, nil
@@ -745,6 +922,17 @@ func searchSharedAssetsByTerms(userID uuid.UUID, terms []string, limit int) ([]m
 	return assets, nil
 }
 
+func collectRecentSharedAssets(userID uuid.UUID, limit int) ([]media.SharedAssetListItem, error) {
+	items, err := media.ListSharedEditableAssets(media.ListAssetsRequest{
+		UserID: userID,
+		Limit:  limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return items.Items, nil
+}
+
 func applyMultiKeywordLike(query *gorm.DB, terms []string, fields []string) *gorm.DB {
 	if len(terms) == 0 || len(fields) == 0 {
 		return query
@@ -780,64 +968,35 @@ func SearchWorkspace(userID uuid.UUID, rawQuery string, limit int) (*SearchRespo
 	}
 
 	terms := tokenizeSearchTerms(query)
+	candidateLimit := normalizeSearchCandidatesLimit(limit)
 
-	type documentRow struct {
-		ID                     uuid.UUID
-		OwnerUserID            uuid.UUID
-		FolderID               *uuid.UUID
-		Title                  string
-		Excerpt                string
-		ManualExcerpt          string
-		PlainText              string
-		ContentJSON            string
-		DocumentType           string
-		PreferredImageTargetID string
-		PublicAccess           string
-		MyRole                 string
-		UpdatedAt              time.Time
-	}
-
-	var documentRows []documentRow
-	selectRole := "COALESCE(perms.role, '') AS my_role"
-	documentQuery := database.DB.
-		Table("documents AS d").
-		Joins("LEFT JOIN document_bodies AS bodies ON bodies.document_id = d.id AND bodies.deleted_at IS NULL")
-	if config.GetCollaborationEnabled() {
-		documentQuery = documentQuery.
-			Joins("LEFT JOIN document_permissions AS perms ON perms.document_id = d.id AND perms.user_id = ? AND perms.deleted_at IS NULL", userID).
-			Where("(d.owner_user_id = ? OR perms.role IN ?)", userID, acl.AllowedRolesForAction(acl.ActionRead))
-	} else {
-		documentQuery = documentQuery.Where("d.owner_user_id = ?", userID)
-		selectRole = "'' AS my_role"
-	}
-	documentQuery = applyMultiKeywordLike(documentQuery, terms, []string{
-		"d.title",
-		"d.excerpt",
-		"d.manual_excerpt",
-		"bodies.plain_text",
-		"bodies.content_json",
-	})
-	if err := documentQuery.
-		Where("d.deleted_at IS NULL").
-		Select(
-			"d.id",
-			"d.owner_user_id",
-			"d.folder_id",
-			"d.title",
-			"d.excerpt",
-			"d.manual_excerpt",
-			"COALESCE(bodies.plain_text, '') AS plain_text",
-			"COALESCE(bodies.content_json, '') AS content_json",
-			"d.document_type",
-			"d.preferred_image_target_id",
-			"d.public_access",
-			selectRole,
-			"d.updated_at",
-		).
-		Order("d.updated_at desc").
-		Limit(limit).
-		Scan(&documentRows).Error; err != nil {
+	documentRows, err := fetchAccessibleDocumentSearchRows(userID, terms, candidateLimit, true)
+	if err != nil {
 		return nil, err
+	}
+
+	if len(documentRows) < limit {
+		existing := make(map[uuid.UUID]struct{}, len(documentRows))
+		for _, row := range documentRows {
+			existing[row.ID] = struct{}{}
+		}
+		fuzzyRows, err := fetchAccessibleDocumentSearchRows(userID, nil, candidateLimit, false)
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range fuzzyRows {
+			if _, ok := existing[row.ID]; ok {
+				continue
+			}
+			if _, matched := scoreSearchValue(row.Title, terms); !matched {
+				excerptText := row.ManualExcerpt + " " + row.Excerpt + " " + row.PlainText + " " + extractPlainTextFromContentJSON(row.ContentJSON)
+				if _, fallbackMatched := scoreSearchValue(excerptText, terms); !fallbackMatched {
+					continue
+				}
+			}
+			documentRows = append(documentRows, row)
+			existing[row.ID] = struct{}{}
+		}
 	}
 
 	for _, row := range documentRows {
@@ -858,15 +1017,47 @@ func SearchWorkspace(userID uuid.UUID, rawQuery string, limit int) (*SearchRespo
 			UpdatedAt:              row.UpdatedAt,
 		})
 	}
+	sort.Slice(result.Documents, func(i, j int) bool {
+		left := result.Documents[i]
+		right := result.Documents[j]
+		leftScore, _ := scoreSearchValue(left.Title, terms)
+		leftExcerptScore, _ := scoreSearchValue(left.Excerpt, terms)
+		rightScore, _ := scoreSearchValue(right.Title, terms)
+		rightExcerptScore, _ := scoreSearchValue(right.Excerpt, terms)
+		totalLeft := leftScore*4 + leftExcerptScore*2
+		totalRight := rightScore*4 + rightExcerptScore*2
+		if totalLeft == totalRight {
+			return left.UpdatedAt.After(right.UpdatedAt)
+		}
+		return totalLeft > totalRight
+	})
+	if len(result.Documents) > limit {
+		result.Documents = result.Documents[:limit]
+	}
 
-	var folders []models.Folder
-	folderQuery := database.DB.Where("owner_user_id = ? AND deleted_at IS NULL", userID)
-	folderQuery = applyMultiKeywordLike(folderQuery, terms, []string{"name"})
-	if err := folderQuery.
-		Order("updated_at desc").
-		Limit(limit).
-		Find(&folders).Error; err != nil {
+	folders, err := fetchOwnedSearchFolders(userID, terms, candidateLimit, true)
+	if err != nil {
 		return nil, err
+	}
+	if len(folders) < limit {
+		existing := make(map[uuid.UUID]struct{}, len(folders))
+		for _, folder := range folders {
+			existing[folder.ID] = struct{}{}
+		}
+		fuzzyFolders, err := fetchOwnedSearchFolders(userID, nil, candidateLimit, false)
+		if err != nil {
+			return nil, err
+		}
+		for _, folder := range fuzzyFolders {
+			if _, ok := existing[folder.ID]; ok {
+				continue
+			}
+			if _, matched := scoreSearchValue(folder.Name, terms); !matched {
+				continue
+			}
+			folders = append(folders, folder)
+			existing[folder.ID] = struct{}{}
+		}
 	}
 	for _, folder := range folders {
 		result.Folders = append(result.Folders, SearchFolderItem{
@@ -875,6 +1066,17 @@ func SearchWorkspace(userID uuid.UUID, rawQuery string, limit int) (*SearchRespo
 			ParentID:  folder.ParentID,
 			UpdatedAt: folder.UpdatedAt,
 		})
+	}
+	sort.Slice(result.Folders, func(i, j int) bool {
+		leftScore, _ := scoreSearchValue(result.Folders[i].Name, terms)
+		rightScore, _ := scoreSearchValue(result.Folders[j].Name, terms)
+		if leftScore == rightScore {
+			return result.Folders[i].UpdatedAt.After(result.Folders[j].UpdatedAt)
+		}
+		return leftScore > rightScore
+	})
+	if len(result.Folders) > limit {
+		result.Folders = result.Folders[:limit]
 	}
 
 	ownedAssets, err := searchOwnedAssetsByTerms(userID, terms, limit)
@@ -886,6 +1088,56 @@ func SearchWorkspace(userID uuid.UUID, rawQuery string, limit int) (*SearchRespo
 		sharedAssets, err = searchSharedAssetsByTerms(userID, terms, limit)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	if len(ownedAssets)+len(sharedAssets) < limit {
+		existingOwned := make(map[uuid.UUID]struct{}, len(ownedAssets))
+		for _, item := range ownedAssets {
+			existingOwned[item.ID] = struct{}{}
+		}
+		recentOwnedAssets, err := collectRecentOwnedAssets(userID, candidateLimit)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range recentOwnedAssets {
+			if _, ok := existingOwned[item.ID]; ok {
+				continue
+			}
+			if _, matched := scoreSearchValue(item.Filename, terms); !matched {
+				continue
+			}
+			ownedAssets = append(ownedAssets, item)
+			existingOwned[item.ID] = struct{}{}
+		}
+		if config.GetCollaborationEnabled() {
+			existingShared := make(map[uuid.UUID]struct{}, len(sharedAssets))
+			for _, item := range sharedAssets {
+				existingShared[item.ID] = struct{}{}
+			}
+			recentSharedAssets, err := collectRecentSharedAssets(userID, candidateLimit)
+			if err != nil {
+				return nil, err
+			}
+			for _, item := range recentSharedAssets {
+				if _, ok := existingShared[item.ID]; ok {
+					continue
+				}
+				titleText := ""
+				if len(item.Documents) > 0 {
+					titleText = item.Documents[0].Title
+				}
+				filenameScore, filenameMatched := scoreSearchValue(item.Filename, terms)
+				titleScore, titleMatched := scoreSearchValue(titleText, terms)
+				if !filenameMatched && !titleMatched {
+					continue
+				}
+				if filenameScore == 0 && titleScore == 0 {
+					continue
+				}
+				sharedAssets = append(sharedAssets, item)
+				existingShared[item.ID] = struct{}{}
+			}
 		}
 	}
 
@@ -942,13 +1194,31 @@ func SearchWorkspace(userID uuid.UUID, rawQuery string, limit int) (*SearchRespo
 
 	result.Media = make([]SearchMediaItem, 0, len(mediaByID))
 	for _, item := range mediaByID {
-		if !matchesSearchTerms(item.Filename, terms) && (item.DocumentTitle == nil || !matchesSearchTerms(*item.DocumentTitle, terms)) {
+		_, filenameMatched := scoreSearchValue(item.Filename, terms)
+		documentTitleMatched := false
+		if item.DocumentTitle != nil {
+			_, documentTitleMatched = scoreSearchValue(*item.DocumentTitle, terms)
+		}
+		if !filenameMatched && !documentTitleMatched {
 			continue
 		}
 		result.Media = append(result.Media, item)
 	}
 	sort.Slice(result.Media, func(i, j int) bool {
-		return result.Media[i].UpdatedAt.After(result.Media[j].UpdatedAt)
+		leftScore, _ := scoreSearchValue(result.Media[i].Filename, terms)
+		rightScore, _ := scoreSearchValue(result.Media[j].Filename, terms)
+		if result.Media[i].DocumentTitle != nil {
+			titleScore, _ := scoreSearchValue(*result.Media[i].DocumentTitle, terms)
+			leftScore += titleScore * 2
+		}
+		if result.Media[j].DocumentTitle != nil {
+			titleScore, _ := scoreSearchValue(*result.Media[j].DocumentTitle, terms)
+			rightScore += titleScore * 2
+		}
+		if leftScore == rightScore {
+			return result.Media[i].UpdatedAt.After(result.Media[j].UpdatedAt)
+		}
+		return leftScore > rightScore
 	})
 	if len(result.Media) > limit {
 		result.Media = result.Media[:limit]

--- a/packages/server/internal/workspace/service.go
+++ b/packages/server/internal/workspace/service.go
@@ -482,12 +482,16 @@ func tokenizeSearchTerms(query string) []string {
 	return terms
 }
 
-func locateSearchMatch(text string, terms []string) (start int, termLength int, ok bool) {
-	textRunes := []rune(text)
-	lowerTextRunes := []rune(strings.ToLower(text))
+type searchMatch struct {
+	start  int
+	length int
+	term   string
+}
 
-	bestStart := -1
-	bestLength := 0
+func collectSearchMatches(text string, terms []string) []searchMatch {
+	lowerTextRunes := []rune(strings.ToLower(text))
+	matches := make([]searchMatch, 0, len(terms))
+
 	for _, term := range terms {
 		termRunes := []rune(strings.ToLower(term))
 		if len(termRunes) == 0 || len(termRunes) > len(lowerTextRunes) {
@@ -498,21 +502,76 @@ func locateSearchMatch(text string, terms []string) (start int, termLength int, 
 			if string(lowerTextRunes[idx:idx+len(termRunes)]) != string(termRunes) {
 				continue
 			}
-			if bestStart == -1 || idx < bestStart || (idx == bestStart && len(termRunes) > bestLength) {
-				bestStart = idx
-				bestLength = len(termRunes)
-			}
+			matches = append(matches, searchMatch{
+				start:  idx,
+				length: len(termRunes),
+				term:   strings.ToLower(term),
+			})
 			break
 		}
 	}
 
-	if bestStart == -1 {
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].start == matches[j].start {
+			return matches[i].length > matches[j].length
+		}
+		return matches[i].start < matches[j].start
+	})
+
+	return matches
+}
+
+func locateSearchMatch(text string, terms []string) (start int, termLength int, ok bool) {
+	textRunes := []rune(text)
+	matches := collectSearchMatches(text, terms)
+	if len(matches) == 0 {
 		return 0, 0, false
 	}
-	if bestStart > len(textRunes) {
+
+	best := matches[0]
+	if best.start > len(textRunes) {
 		return 0, 0, false
 	}
-	return bestStart, bestLength, true
+	return best.start, best.length, true
+}
+
+func locateBestSnippetWindow(text string, terms []string, radius int) (start int, end int, ok bool) {
+	textRunes := []rune(text)
+	matches := collectSearchMatches(text, terms)
+	if len(matches) == 0 {
+		return 0, 0, false
+	}
+
+	bestCoverage := -1
+	bestStart := 0
+	bestEnd := 0
+	bestAnchor := len(textRunes)
+
+	for _, anchor := range matches {
+		windowStart := max(0, anchor.start-radius)
+		windowEnd := min(len(textRunes), anchor.start+anchor.length+radius)
+		coveredTerms := make(map[string]struct{}, len(terms))
+		for _, candidate := range matches {
+			if candidate.start >= windowStart && candidate.start < windowEnd {
+				coveredTerms[candidate.term] = struct{}{}
+			}
+		}
+
+		coverage := len(coveredTerms)
+		if coverage > bestCoverage ||
+			(coverage == bestCoverage && anchor.start < bestAnchor) ||
+			(coverage == bestCoverage && anchor.start == bestAnchor && windowEnd-windowStart > bestEnd-bestStart) {
+			bestCoverage = coverage
+			bestStart = windowStart
+			bestEnd = windowEnd
+			bestAnchor = anchor.start
+		}
+	}
+
+	if bestCoverage <= 0 {
+		return 0, 0, false
+	}
+	return bestStart, bestEnd, true
 }
 
 func extractSearchSnippet(text, query string, radius int) string {
@@ -531,13 +590,10 @@ func extractSearchSnippet(text, query string, radius int) string {
 
 	textRunes := []rune(trimmedText)
 	terms := tokenizeSearchTerms(trimmedQuery)
-	matchIndex, matchLength, ok := locateSearchMatch(trimmedText, terms)
+	start, end, ok := locateBestSnippetWindow(trimmedText, terms, radius)
 	if !ok {
 		return ""
 	}
-
-	start := max(0, matchIndex-radius)
-	end := min(len(textRunes), matchIndex+matchLength+radius)
 
 	snippet := string(textRunes[start:end])
 	if start > 0 {
@@ -598,6 +654,95 @@ func buildDocumentSearchSnippetFromSources(excerpt, manualExcerpt, plainText, co
 		return snippet
 	}
 	return resolveDocumentListExcerpt(excerpt, manualExcerpt)
+}
+
+func matchesSearchTerms(value string, terms []string) bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || len(terms) == 0 {
+		return false
+	}
+
+	lowerValue := strings.ToLower(trimmed)
+	for _, term := range terms {
+		if strings.Contains(lowerValue, strings.ToLower(term)) {
+			return true
+		}
+	}
+	return false
+}
+
+func searchOwnedAssetsByTerms(userID uuid.UUID, terms []string, limit int) ([]media.AssetListItem, error) {
+	if len(terms) == 0 {
+		return nil, nil
+	}
+
+	queries := append([]string{strings.Join(terms, " ")}, terms...)
+	assetsByID := make(map[uuid.UUID]media.AssetListItem, limit*len(queries))
+	for _, term := range queries {
+		items, err := media.ListOwnedAssets(media.ListAssetsRequest{
+			UserID: userID,
+			Query:  term,
+			Limit:  limit,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range items.Items {
+			existing, exists := assetsByID[item.ID]
+			if !exists || item.UpdatedAt.After(existing.UpdatedAt) {
+				assetsByID[item.ID] = item
+			}
+		}
+	}
+
+	assets := make([]media.AssetListItem, 0, len(assetsByID))
+	for _, item := range assetsByID {
+		assets = append(assets, item)
+	}
+	sort.Slice(assets, func(i, j int) bool {
+		return assets[i].UpdatedAt.After(assets[j].UpdatedAt)
+	})
+	if len(assets) > limit {
+		assets = assets[:limit]
+	}
+	return assets, nil
+}
+
+func searchSharedAssetsByTerms(userID uuid.UUID, terms []string, limit int) ([]media.SharedAssetListItem, error) {
+	if len(terms) == 0 {
+		return nil, nil
+	}
+
+	queries := append([]string{strings.Join(terms, " ")}, terms...)
+	assetsByID := make(map[uuid.UUID]media.SharedAssetListItem, limit*len(queries))
+	for _, term := range queries {
+		items, err := media.ListSharedEditableAssets(media.ListAssetsRequest{
+			UserID: userID,
+			Query:  term,
+			Limit:  limit,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range items.Items {
+			existing, exists := assetsByID[item.ID]
+			if !exists || item.UpdatedAt.After(existing.UpdatedAt) {
+				assetsByID[item.ID] = item
+			}
+		}
+	}
+
+	assets := make([]media.SharedAssetListItem, 0, len(assetsByID))
+	for _, item := range assetsByID {
+		assets = append(assets, item)
+	}
+	sort.Slice(assets, func(i, j int) bool {
+		return assets[i].UpdatedAt.After(assets[j].UpdatedAt)
+	})
+	if len(assets) > limit {
+		assets = assets[:limit]
+	}
+	return assets, nil
 }
 
 func applyMultiKeywordLike(query *gorm.DB, terms []string, fields []string) *gorm.DB {
@@ -669,6 +814,7 @@ func SearchWorkspace(userID uuid.UUID, rawQuery string, limit int) (*SearchRespo
 		"d.title",
 		"d.excerpt",
 		"d.manual_excerpt",
+		"bodies.plain_text",
 		"bodies.content_json",
 	})
 	if err := documentQuery.
@@ -731,21 +877,13 @@ func SearchWorkspace(userID uuid.UUID, rawQuery string, limit int) (*SearchRespo
 		})
 	}
 
-	ownedAssets, err := media.ListOwnedAssets(media.ListAssetsRequest{
-		UserID: userID,
-		Query:  query,
-		Limit:  limit,
-	})
+	ownedAssets, err := searchOwnedAssetsByTerms(userID, terms, limit)
 	if err != nil {
 		return nil, err
 	}
-	sharedAssets := &media.ListSharedAssetsResult{}
+	sharedAssets := []media.SharedAssetListItem{}
 	if config.GetCollaborationEnabled() {
-		sharedAssets, err = media.ListSharedEditableAssets(media.ListAssetsRequest{
-			UserID: userID,
-			Query:  query,
-			Limit:  limit,
-		})
+		sharedAssets, err = searchSharedAssetsByTerms(userID, terms, limit)
 		if err != nil {
 			return nil, err
 		}
@@ -769,7 +907,7 @@ func SearchWorkspace(userID uuid.UUID, rawQuery string, limit int) (*SearchRespo
 		return document.Title
 	}
 
-	mediaByID := make(map[uuid.UUID]SearchMediaItem, len(ownedAssets.Items)+len(sharedAssets.Items))
+	mediaByID := make(map[uuid.UUID]SearchMediaItem, len(ownedAssets)+len(sharedAssets))
 	appendMediaItem := func(assetID uuid.UUID, filename, kind, mimeType string, documentID *uuid.UUID, updatedAt time.Time) {
 		item := SearchMediaItem{
 			ID:         assetID,
@@ -791,10 +929,10 @@ func SearchWorkspace(userID uuid.UUID, rawQuery string, limit int) (*SearchRespo
 		}
 	}
 
-	for _, item := range ownedAssets.Items {
+	for _, item := range ownedAssets {
 		appendMediaItem(item.ID, item.Filename, item.Kind, item.MimeType, item.DocumentID, item.UpdatedAt)
 	}
-	for _, item := range sharedAssets.Items {
+	for _, item := range sharedAssets {
 		var documentID *uuid.UUID
 		if len(item.Documents) > 0 {
 			documentID = &item.Documents[0].DocumentID
@@ -804,6 +942,9 @@ func SearchWorkspace(userID uuid.UUID, rawQuery string, limit int) (*SearchRespo
 
 	result.Media = make([]SearchMediaItem, 0, len(mediaByID))
 	for _, item := range mediaByID {
+		if !matchesSearchTerms(item.Filename, terms) && (item.DocumentTitle == nil || !matchesSearchTerms(*item.DocumentTitle, terms)) {
+			continue
+		}
 		result.Media = append(result.Media, item)
 	}
 	sort.Slice(result.Media, func(i, j int) bool {

--- a/packages/web/src/routes/edit/documents/[id]/+page.ts
+++ b/packages/web/src/routes/edit/documents/[id]/+page.ts
@@ -1,0 +1,2 @@
+export const ssr = false;
+export const csr = true;


### PR DESCRIPTION
This pull request enhances the multi-keyword search functionality for workspace documents and associated media, improving both the relevance of search results and the quality of generated snippets. It introduces more sophisticated logic to ensure that search snippets and media hits better reflect all search terms, and adds new utility functions to support these improvements. Additionally, it enables client-side rendering for a specific web page.

**Workspace Search Improvements:**

* Improved snippet generation to prefer windows of text that cover the most search terms, rather than just the first or longest match. This results in more relevant and informative excerpts in search results. [[1]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9L501-R574) [[2]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9L534-L541)
* Enhanced media search to require that media matches at least one search term in either the filename or associated document title, and to aggregate results across both owned and shared assets for all search terms. [[1]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9R659-R747) [[2]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9L734-R886) [[3]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9L772-R910) [[4]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9L794-R935) [[5]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9R945-R947)

**Testing:**

* Added and updated tests to verify that multi-keyword searches correctly prefer snippets and media hits that include all relevant keyword contexts.

**Web Rendering:**

* Enabled client-side rendering (CSR) and disabled server-side rendering (SSR) for the `edit/documents/[id]` page to improve interactivity and performance. ([packages/web/src/routes/edit/documents/[id]/+page.tsR1-R2](diffhunk://#diff-83872daef3639eeb19621f761eb9c8646c4e0d1010d9d66fb535461adbd26176R1-R2))Refactor search matching to collect all term occurrences and pick a best snippet window that maximizes coverage across multiple keywords. Add helpers to search owned/shared assets by combined and individual terms, deduplicate results by newest update, and filter media hits by actual filename or linked document title matches. Include bodies.plain_text in searchable document fields. Add tests for multi-keyword media matches and disable SSR for the edit document page.