### PR TITLE
fix(jwt): when no jwt key, the init process cannot work correctly.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@
 # 未列出的变量一般代表当前开发环境下可使用默认值。
 # =========================
 
+# ---- Global / 全局设置 ----
+# 环境设置，默认 production
+ENV=production
+
 # ---- 认证 / 会话 ----
 # Access Token 与媒体签名等默认都会依赖这把密钥。
 JWT_SECRET_KEY=replace-with-a-strong-secret

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ ENV=production
 # Access Token 与媒体签名等默认都会依赖这把密钥。
 JWT_SECRET_KEY=replace-with-a-strong-secret
 
+# APP_ENCRYPTION_KEY is used to encrypt the app data, it is also a SHA256 hash
+APP_ENCRYPTION_KEY=replace-with-a-strong-secret
+
 # Access Token 生命周期（分钟），默认 15
 ACCESS_TOKEN_LIFETIME_MINUTES=15
 

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ Cloudflare Pages 构建如果涉及 Node 内建模块兼容，仓库内已经提
     # 进入后端目录
     cd packages/server
 
-    # 建议先从仓库根目录的 .env.example 复制一份
-    # cp ../.env.example .env
+    # 对数据服务进行初始化操作,并注入 Oauth 服务以便接下来的操作
+    ENV=DEVELOPMENT go run ./cmd/init/main.go
 
     # 运行后端
-    go run ./cmd/server/main.go
+    ENV=DEVELOPMENT go run ./server/main.go
     ```
     后端服务将运行在 `http://localhost:8080`。
     说明：后端启动会自动读取 `packages/server/.env`。

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Cloudflare Pages 构建如果涉及 Node 内建模块兼容，仓库内已经提
     ENV=DEVELOPMENT go run ./cmd/init/main.go
 
     # 运行后端
-    ENV=DEVELOPMENT go run ./server/main.go
+    ENV=DEVELOPMENT go run ./cmd/server/main.go
     ```
     后端服务将运行在 `http://localhost:8080`。
     说明：后端启动会自动读取 `packages/server/.env`。

--- a/packages/server/cmd/init/main.go
+++ b/packages/server/cmd/init/main.go
@@ -2,15 +2,18 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"g.co1d.in/Coldin04/Cyime/server/internal/config"
 	"g.co1d.in/Coldin04/Cyime/server/internal/database"
 	"g.co1d.in/Coldin04/Cyime/server/internal/models"
 	"g.co1d.in/Coldin04/Cyime/server/internal/securevalue"
+	"g.co1d.in/Coldin04/Cyime/server/internal/utils"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
@@ -56,7 +59,41 @@ var providerTemplates = map[string]ProviderTemplate{
 }
 
 func main() {
-	_ = config.LoadDotEnv(".env")
+	err := config.LoadDotEnv(".env")
+	if err != nil {
+		switch {
+		case strings.ToLower(os.Getenv("ENV")) == "development":
+			// create an .env before to ensure the next step work fine.:<
+			// get env from root of this project before, if not exist, generate a minimal one.
+			log.Println(".env 没有找到，正在从 .env.example 中复制配置")
+			runtimeCallerPath := utils.GetRunTimeCallerPath()
+			envExamplePath := filepath.Join(runtimeCallerPath, "../../", ".env.example")
+			envPath := filepath.Join(runtimeCallerPath, ".env")
+			envExampleFile, err := os.ReadFile(envExamplePath)
+			if err != nil {
+				log.Fatalf("读取 .env.example 失败: %v, 请通过原始 ENV 获取一份 ENV 样本后重试流程!", err)
+			}
+			err = os.WriteFile(envPath, envExampleFile, 0644)
+			if err != nil {
+				log.Fatalf("创建 .env 失败: %v", err)
+				return
+			}
+			// replace the JWT_SECRET_KEY with a random SHA256 hash
+			jwtSecretKey := utils.GenerateRandomSHA256()
+			envExampleFile = bytes.ReplaceAll(envExampleFile, []byte("JWT_SECRET_KEY=replace-with-a-strong-secret"), []byte("JWT_SECRET_KEY="+jwtSecretKey))
+			err = os.WriteFile(envPath, envExampleFile, 0644)
+			if err != nil {
+				log.Fatalf("替换 JWT_SECRET_KEY 失败: %v", err)
+				return
+			}
+			fmt.Println("已创建 .env 文件")
+			fmt.Println("请修改 .env 文件中的配置，然后重新运行初始化工具")
+			return
+		default:
+			log.Fatalf("加载 .env 失败: %v, 请检查 .env 文件是否存在且正确配置", err)
+			return
+		}
+	}
 
 	fmt.Println("🍋 Cyime 初始化向导")
 	fmt.Println("========================")

--- a/packages/server/cmd/init/main.go
+++ b/packages/server/cmd/init/main.go
@@ -80,7 +80,9 @@ func main() {
 			}
 			// replace the JWT_SECRET_KEY with a random SHA256 hash
 			jwtSecretKey := utils.GenerateRandomSHA256()
+			appEncryptionKey := utils.GenerateRandomSHA256()
 			envExampleFile = bytes.ReplaceAll(envExampleFile, []byte("JWT_SECRET_KEY=replace-with-a-strong-secret"), []byte("JWT_SECRET_KEY="+jwtSecretKey))
+			envExampleFile = bytes.ReplaceAll(envExampleFile, []byte("APP_ENCRYPTION_KEY=replace-with-a-strong-secret"), []byte("APP_ENCRYPTION_KEY="+appEncryptionKey))
 			err = os.WriteFile(envPath, envExampleFile, 0644)
 			if err != nil {
 				log.Fatalf("替换 JWT_SECRET_KEY 失败: %v", err)

--- a/packages/server/internal/utils/runtime_calller.go
+++ b/packages/server/internal/utils/runtime_calller.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// GetRunTimeCaller will return the current runner when Crafting this project, ONLY FOR DEV.
+func GetRunTimeCallerPathDEV() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Dir(filename)
+}
+
+func GetRunTimeCallerPathPROD() string {
+	cmd, _ := os.Getwd()
+	return cmd
+}
+
+func GetRunTimeCallerPath() string {
+	if os.Getenv("ENV") == "development" {
+		return GetRunTimeCallerPathDEV()
+	}
+	return GetRunTimeCallerPathPROD()
+}

--- a/packages/server/internal/utils/sha256_generator.go
+++ b/packages/server/internal/utils/sha256_generator.go
@@ -1,0 +1,17 @@
+// package utils is a utility package for the server, this is sha256_generator.go
+package utils
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// GenerateRandomSHA256 returns a hex-encoded random SHA256 hash string.
+// It generates 32 random bytes and returns their SHA256 hex digest.
+func GenerateRandomSHA256() string {
+	randomBytes := make([]byte, 32)
+	rand.Read(randomBytes)
+	sum := sha256.Sum256(randomBytes)
+	return hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
在 Init 流程中，代码会调用到 securevalue.EncryptString 函数

```Golang
	if !strings.HasPrefix(provider.ClientSecretEncrypted, securevalue.EncryptedValuePrefix) && provider.ClientSecretEncrypted != "" {
		encryptedSecret, err := securevalue.EncryptString(provider.ClientSecretEncrypted)
		if err != nil {
			log.Fatalf("加密提供商密钥失败：%v", err)
		}
		provider.ClientSecretEncrypted = encryptedSecret
	}
```

但是这个函数依赖 LoadKey，即使用了 APP_ENCRYPTION_KEY 和 JWT_SECRET 的环境变量


```Golang

func loadKey() ([]byte, error) {
	secret := strings.TrimSpace(os.Getenv("APP_ENCRYPTION_KEY"))
	if secret == "" {
		secret = strings.TrimSpace(os.Getenv("JWT_SECRET_KEY"))
	}
	if secret == "" {
		return nil, errors.New("missing APP_ENCRYPTION_KEY (or JWT_SECRET_KEY fallback)")
	}

	sum := sha256.Sum256([]byte(secret))
	return sum[:], nil
}


```

如果用户只是单纯的复制了一份的话，密钥保护将使用默认参数，在设计上不够安全，这一部分可以通过调用 Sha256 库用以解决

并且增加对 Development 的说明，以方便开发者调试
