### PR TITLE
Fix stale document invite authorization

### DIFF
--- a/packages/server/internal/workspace/invite_notification_service.go
+++ b/packages/server/internal/workspace/invite_notification_service.go
@@ -18,6 +18,7 @@ const (
 	documentInviteStatusSent       = "sent"
 	documentInviteStatusAccepted   = "accepted"
 	documentInviteStatusDeclined   = "declined"
+	documentInviteStatusCanceled   = "canceled"
 	notificationTypeDocumentInvite = "document_invite"
 )
 
@@ -223,6 +224,9 @@ func AcceptDocumentInvite(userID, inviteID uuid.UUID) error {
 		if !acl.RoleAllowsAction(invite.Role, acl.ActionRead) {
 			return ErrInviteInvalidRole
 		}
+		if err := ensureDocumentInviteStillAuthorized(tx, invite); err != nil {
+			return err
+		}
 		if err := upsertDocumentPermission(tx, invite.DocumentID, userID, invite.InviterUserID, invite.Role); err != nil {
 			return err
 		}
@@ -277,6 +281,20 @@ func DeclineDocumentInvite(userID, inviteID uuid.UUID) error {
 				"updated_at": now,
 			}).Error
 	})
+}
+
+func ensureDocumentInviteStillAuthorized(tx *gorm.DB, invite models.DocumentInvite) error {
+	_, inviterRole, err := acl.CanManageDocumentMembers(tx, invite.InviterUserID, invite.DocumentID)
+	if err != nil {
+		if errors.Is(err, acl.ErrDocumentNotFoundOrForbidden) {
+			return ErrInviteInvalidStatus
+		}
+		return err
+	}
+	if inviterRole == acl.RoleCollaborator && invite.Role == acl.RoleCollaborator {
+		return ErrInviteInvalidRole
+	}
+	return nil
 }
 
 func upsertDocumentPermission(tx *gorm.DB, documentID, targetUserID, createdBy uuid.UUID, role string) error {

--- a/packages/server/internal/workspace/service.go
+++ b/packages/server/internal/workspace/service.go
@@ -253,7 +253,17 @@ func RemoveDocumentMember(actorUserID, documentID, targetUserID uuid.UUID) (*Sha
 			return ErrCollaboratorRemoveRestricted
 		}
 
-		return tx.Where("document_id = ? AND user_id = ?", documentID, targetUserID).Delete(&models.DocumentPermission{}).Error
+		if err := tx.Where("document_id = ? AND user_id = ?", documentID, targetUserID).Delete(&models.DocumentPermission{}).Error; err != nil {
+			return err
+		}
+
+		now := time.Now()
+		return tx.Model(&models.DocumentInvite{}).
+			Where("document_id = ? AND (inviter_user_id = ? OR invitee_user_id = ?) AND status = ?", documentID, targetUserID, targetUserID, documentInviteStatusSent).
+			Updates(map[string]any{
+				"status":     documentInviteStatusCanceled,
+				"updated_at": now,
+			}).Error
 	})
 	if err != nil {
 		return nil, err

--- a/packages/server/internal/workspace/service_security_test.go
+++ b/packages/server/internal/workspace/service_security_test.go
@@ -657,6 +657,53 @@ func TestShareDocument_RevivesSoftDeletedPermission(t *testing.T) {
 	}
 }
 
+func TestAcceptDocumentInviteRejectsInviteAfterInviterRevoked(t *testing.T) {
+	db := setupWorkspaceTestDB(t)
+	ownerID := uuid.New()
+	collaboratorID := uuid.New()
+	inviteeID := uuid.New()
+	seedVerifiedUser(t, db, collaboratorID, "collaborator@example.com")
+	seedVerifiedUser(t, db, inviteeID, "invitee@example.com")
+	docID := seedDocumentForWorkspace(t, db, ownerID, "shared-doc")
+	seedWorkspacePermission(t, db, docID, collaboratorID, ownerID, acl.RoleCollaborator)
+
+	if _, err := InviteDocumentByEmail(collaboratorID, docID, "invitee@example.com", acl.RoleEditor); err != nil {
+		t.Fatalf("invite document: %v", err)
+	}
+
+	var invite models.DocumentInvite
+	if err := db.Where("document_id = ? AND inviter_user_id = ? AND invitee_user_id = ?", docID, collaboratorID, inviteeID).First(&invite).Error; err != nil {
+		t.Fatalf("load invite: %v", err)
+	}
+
+	if _, err := RemoveDocumentMember(ownerID, docID, collaboratorID); err != nil {
+		t.Fatalf("remove collaborator: %v", err)
+	}
+
+	err := AcceptDocumentInvite(inviteeID, invite.ID)
+	if !errors.Is(err, ErrInviteInvalidStatus) {
+		t.Fatalf("expected invalid invite status after inviter revocation, got %v", err)
+	}
+
+	var permissionCount int64
+	if err := db.Model(&models.DocumentPermission{}).
+		Where("document_id = ? AND user_id = ? AND deleted_at IS NULL", docID, inviteeID).
+		Count(&permissionCount).Error; err != nil {
+		t.Fatalf("count invitee permissions: %v", err)
+	}
+	if permissionCount != 0 {
+		t.Fatalf("expected no invitee permission, got %d", permissionCount)
+	}
+
+	var updatedInvite models.DocumentInvite
+	if err := db.First(&updatedInvite, "id = ?", invite.ID).Error; err != nil {
+		t.Fatalf("reload invite: %v", err)
+	}
+	if updatedInvite.Status != documentInviteStatusCanceled {
+		t.Fatalf("expected invite canceled, got %s", updatedInvite.Status)
+	}
+}
+
 func TestListSharedDocuments_ReturnsPermissionedDocs(t *testing.T) {
 	db := setupWorkspaceTestDB(t)
 	ownerID := uuid.New()


### PR DESCRIPTION
### Motivation
- Prevent pending document invites from being accepted based on stale authorization when the inviter has been revoked or otherwise lost manage-members rights.
- Cancel pending invites that reference members who are removed so revoked collaborators cannot leave a valid acceptance path behind.

### Description
- Add a new invite status `documentInviteStatusCanceled` and surface it in `invite_notification_service.go` to represent canceled pending invites.
- Revalidate the inviter's current ability to manage members during accept by adding `ensureDocumentInviteStillAuthorized(tx, invite)` and calling it from `AcceptDocumentInvite` before creating permissions.
- Update `RemoveDocumentMember` in `service.go` to cancel any pending invites where the removed user is either the `inviter_user_id` or `invitee_user_id` so invites are removed when a member is revoked.
- Add a regression test `TestAcceptDocumentInviteRejectsInviteAfterInviterRevoked` in `service_security_test.go` which seeds an owner/collaborator/invitee, creates a pending invite from the collaborator, removes the collaborator, and asserts that acceptance fails, no permission is created, and the invite is marked canceled.

### Testing
- Ran the targeted tests with `cd packages/server && go test ./internal/workspace -run 'TestAcceptDocumentInviteRejectsInviteAfterInviterRevoked|TestAcceptDocumentInviteHandler_UpdatesInviteStatusAndMarksNotificationRead' -count=1 -v` and the cases exercising the fix passed.
- Ran the full package tests with `cd packages/server && go test ./internal/workspace -count=1` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc1ad01078832b9df6f09fa51131d9)