### PR TITLE
Limit thumbnail decoding resources

### DIFF
--- a/packages/server/internal/media/service.go
+++ b/packages/server/internal/media/service.go
@@ -132,6 +132,8 @@ const blobThumbnailStatusPending = "pending"
 const blobThumbnailStatusFailed = "failed"
 const blobThumbnailStatusSkipped = "skipped"
 const blobThumbnailMaxEdge = 320
+const blobThumbnailMaxSourceEdge = 12000
+const blobThumbnailMaxSourcePixels int64 = 50_000_000
 
 type assetBlobRecord struct {
 	Asset models.Asset
@@ -1169,7 +1171,11 @@ func shouldGenerateBlobThumbnail(blob models.BlobObject) bool {
 	if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(blob.MimeType)), "image/") {
 		return false
 	}
-	if blob.ThumbnailStatus == blobThumbnailStatusReady && strings.TrimSpace(blob.ThumbnailObjectKey) != "" {
+	status := strings.ToLower(strings.TrimSpace(blob.ThumbnailStatus))
+	if status == blobThumbnailStatusFailed || status == blobThumbnailStatusSkipped {
+		return false
+	}
+	if status == blobThumbnailStatusReady && strings.TrimSpace(blob.ThumbnailObjectKey) != "" {
 		return false
 	}
 	return true
@@ -1275,16 +1281,26 @@ func markBlobThumbnailState(blobID uuid.UUID, status string, extra map[string]an
 }
 
 func buildBlobThumbnail(sourceBytes []byte, mimeType string) ([]byte, string, *int, *int, error) {
+	config, _, err := image.DecodeConfig(bytes.NewReader(sourceBytes))
+	if err != nil {
+		return nil, "", nil, nil, fmt.Errorf("unsupported image for thumbnail: %w", err)
+	}
+	srcW := config.Width
+	srcH := config.Height
+	if err := validateBlobThumbnailSourceSize(srcW, srcH); err != nil {
+		return nil, "", nil, nil, err
+	}
+
 	img, _, err := image.Decode(bytes.NewReader(sourceBytes))
 	if err != nil {
 		return nil, "", nil, nil, fmt.Errorf("unsupported image for thumbnail: %w", err)
 	}
 
 	bounds := img.Bounds()
-	srcW := bounds.Dx()
-	srcH := bounds.Dy()
-	if srcW <= 0 || srcH <= 0 {
-		return nil, "", nil, nil, errors.New("invalid image size")
+	srcW = bounds.Dx()
+	srcH = bounds.Dy()
+	if err := validateBlobThumbnailSourceSize(srcW, srcH); err != nil {
+		return nil, "", nil, nil, err
 	}
 	if srcW <= blobThumbnailMaxEdge && srcH <= blobThumbnailMaxEdge {
 		return nil, "", nil, nil, nil
@@ -1309,6 +1325,20 @@ func buildBlobThumbnail(sourceBytes []byte, mimeType string) ([]byte, string, *i
 	width := dstW
 	height := dstH
 	return encoded.Bytes(), thumbMime, &width, &height, nil
+}
+
+func validateBlobThumbnailSourceSize(width, height int) error {
+	if width <= 0 || height <= 0 {
+		return errors.New("invalid image size")
+	}
+	if width > blobThumbnailMaxSourceEdge || height > blobThumbnailMaxSourceEdge {
+		return fmt.Errorf("unsupported image for thumbnail: dimensions %dx%d exceed maximum edge %d", width, height, blobThumbnailMaxSourceEdge)
+	}
+	pixels := int64(width) * int64(height)
+	if pixels > blobThumbnailMaxSourcePixels {
+		return fmt.Errorf("unsupported image for thumbnail: dimensions %dx%d exceed maximum pixels %d", width, height, blobThumbnailMaxSourcePixels)
+	}
+	return nil
 }
 
 func fitWithin(srcW, srcH, maxEdge int) (int, int) {

--- a/packages/server/internal/media/service_test.go
+++ b/packages/server/internal/media/service_test.go
@@ -3,8 +3,10 @@ package media
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"mime/multipart"
 	"net/http/httptest"
 	"os"
@@ -112,6 +114,55 @@ func makeFileHeader(t *testing.T, fieldName, filename string, content []byte) *m
 		t.Fatalf("parse multipart form: %v", err)
 	}
 	return req.MultipartForm.File[fieldName][0]
+}
+
+func TestBuildBlobThumbnailRejectsOversizedPNGBeforeDecode(t *testing.T) {
+	pngBytes := makePNGHeaderOnly(t, blobThumbnailMaxSourceEdge+1, blobThumbnailMaxSourceEdge+1)
+
+	_, _, _, _, err := buildBlobThumbnail(pngBytes, "image/png")
+	if err == nil {
+		t.Fatalf("expected oversized PNG to be rejected")
+	}
+	if !strings.Contains(err.Error(), "exceed maximum edge") {
+		t.Fatalf("expected maximum edge error, got %v", err)
+	}
+}
+
+func TestShouldGenerateBlobThumbnailDoesNotRetryTerminalStatuses(t *testing.T) {
+	for _, status := range []string{blobThumbnailStatusFailed, blobThumbnailStatusSkipped} {
+		blob := models.BlobObject{MimeType: "image/png", ThumbnailStatus: status}
+		if shouldGenerateBlobThumbnail(blob) {
+			t.Fatalf("expected status %q not to be scheduled", status)
+		}
+	}
+
+	if !shouldGenerateBlobThumbnail(models.BlobObject{MimeType: "image/png", ThumbnailStatus: blobThumbnailStatusPending}) {
+		t.Fatalf("expected pending image thumbnail to be scheduled")
+	}
+}
+
+func makePNGHeaderOnly(t *testing.T, width, height int) []byte {
+	t.Helper()
+	var out bytes.Buffer
+	out.Write([]byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a})
+
+	ihdr := make([]byte, 13)
+	binary.BigEndian.PutUint32(ihdr[0:4], uint32(width))
+	binary.BigEndian.PutUint32(ihdr[4:8], uint32(height))
+	ihdr[8] = 8 // bit depth
+	ihdr[9] = 6 // RGBA color type
+	writePNGChunk(&out, "IHDR", ihdr)
+	return out.Bytes()
+}
+
+func writePNGChunk(out *bytes.Buffer, chunkType string, data []byte) {
+	_ = binary.Write(out, binary.BigEndian, uint32(len(data)))
+	out.WriteString(chunkType)
+	out.Write(data)
+	crc := crc32.NewIEEE()
+	_, _ = crc.Write([]byte(chunkType))
+	_, _ = crc.Write(data)
+	_ = binary.Write(out, binary.BigEndian, crc.Sum32())
 }
 
 func TestUploadDocumentAsset_DeduplicatesByHashAndSize(t *testing.T) {

--- a/packages/server/internal/media/worker.go
+++ b/packages/server/internal/media/worker.go
@@ -284,7 +284,7 @@ func RunBlobThumbnailReconcilePass(ctx context.Context, batchSize int) (int, err
 		Where("id IN (?)", subQuery).
 		Where("deleted_at IS NULL").
 		Where("mime_type LIKE ?", "image/%").
-		Where("thumbnail_status <> ? OR thumbnail_object_key = '' OR thumbnail_object_key IS NULL", blobThumbnailStatusReady).
+		Where("thumbnail_status = ? OR thumbnail_status = '' OR thumbnail_status IS NULL OR (thumbnail_status = ? AND (thumbnail_object_key = '' OR thumbnail_object_key IS NULL))", blobThumbnailStatusPending, blobThumbnailStatusReady).
 		Order("updated_at asc").
 		Limit(batchSize).
 		Find(&blobs).Error; err != nil {

--- a/packages/server/internal/media/worker_test.go
+++ b/packages/server/internal/media/worker_test.go
@@ -12,6 +12,7 @@ import (
 
 type mockStorageProvider struct {
 	deleteCalls []string
+	getCalls    []string
 	deleteErr   error
 }
 
@@ -23,13 +24,60 @@ func (m *mockStorageProvider) PutObject(_ context.Context, _ PutObjectInput) (*P
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockStorageProvider) GetObject(_ context.Context, _ string) (*GetObjectResult, error) {
+func (m *mockStorageProvider) GetObject(_ context.Context, objectKey string) (*GetObjectResult, error) {
+	m.getCalls = append(m.getCalls, objectKey)
 	return nil, errors.New("not implemented")
 }
 
 func (m *mockStorageProvider) DeleteObject(_ context.Context, objectKey string) error {
 	m.deleteCalls = append(m.deleteCalls, objectKey)
 	return m.deleteErr
+}
+
+func TestRunBlobThumbnailReconcilePassSkipsTerminalStatuses(t *testing.T) {
+	db := setupMediaTestDB(t)
+	userID := uuid.New()
+	docID := seedOwnedDocument(t, db, userID)
+
+	mock := &mockStorageProvider{}
+	storageProvider = mock
+	t.Cleanup(func() { storageProvider = nil })
+
+	for _, status := range []string{blobThumbnailStatusFailed, blobThumbnailStatusSkipped} {
+		blob := seedBlob(t, db, "owner/"+status+".png", "image/png", 1, "hash-"+status)
+		if err := db.Model(&models.BlobObject{}).
+			Where("id = ?", blob.ID).
+			Update("thumbnail_status", status).Error; err != nil {
+			t.Fatalf("set thumbnail status: %v", err)
+		}
+		asset := models.Asset{
+			ID:             uuid.New(),
+			OwnerUserID:    userID,
+			DocumentID:     &docID,
+			BlobID:         blob.ID,
+			Kind:           "image",
+			Filename:       status + ".png",
+			URL:            blob.URL,
+			Visibility:     "private",
+			Status:         "ready",
+			ReferenceCount: 0,
+			CreatedBy:      userID,
+		}
+		if err := db.Create(&asset).Error; err != nil {
+			t.Fatalf("create asset: %v", err)
+		}
+	}
+
+	backfilled, err := RunBlobThumbnailReconcilePass(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("reconcile thumbnails: %v", err)
+	}
+	if backfilled != 0 {
+		t.Fatalf("expected no terminal thumbnails backfilled, got %d", backfilled)
+	}
+	if len(mock.getCalls) != 0 {
+		t.Fatalf("expected terminal thumbnails not to fetch storage, got %+v", mock.getCalls)
+	}
 }
 
 func TestRunDueAssetGCJobs_DeletesUnusedAssets(t *testing.T) {


### PR DESCRIPTION
### Motivation
- Prevent image-bomb denial-of-service by validating source image dimensions/pixels before performing a full decode and by avoiding repeated/unbounded thumbnail work.

### Description
- Add source limits `blobThumbnailMaxSourceEdge` and `blobThumbnailMaxSourcePixels` and validate them via a new `validateBlobThumbnailSourceSize` helper called before and after decoding. (changes in `packages/server/internal/media/service.go`)
- Use `image.DecodeConfig` to inspect dimensions before `image.Decode` so extremely large encoded images are rejected before memory allocation. (changes in `packages/server/internal/media/service.go`)
- Treat `failed` and `skipped` thumbnail statuses as terminal to prevent repeated inline scheduling and reconciliation retries by updating `shouldGenerateBlobThumbnail` and the reconciliation selection query. (changes in `packages/server/internal/media/service.go` and `packages/server/internal/media/worker.go`)
- Add regression tests to cover oversized-PNG rejection and terminal-status handling and a reconcile test to ensure terminal thumbnails are not refetched. (changes in `packages/server/internal/media/service_test.go` and `packages/server/internal/media/worker_test.go`)

### Testing
- Ran `go test ./internal/media` and the media package tests passed (`ok g.co1d.in/Coldin04/Cyime/server/internal/media`).
- Ran targeted tests `TestBuildBlobThumbnailRejectsOversizedPNGBeforeDecode` and `TestShouldGenerateBlobThumbnailDoesNotRetryTerminalStatuses` which passed. 
- Ran `go test ./...` which surfaced an unrelated existing failure in the auth package (`TestGetUserProfile_ParsesGoogleOAuthUserInfoAsTrusted`), but the media package changes do not cause that failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc14a7c538832b9eddce41b4729be9)