### PR TITLE
Fix/security audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,9 @@ ENV=production
 # Access Token 与媒体签名等默认都会依赖这把密钥。
 JWT_SECRET_KEY=replace-with-a-strong-secret
 
-# APP_ENCRYPTION_KEY is used to encrypt the app data, it is also a SHA256 hash
-APP_ENCRYPTION_KEY=replace-with-a-strong-secret
+# APP_ENCRYPTION_KEY encrypts stored OAuth client secrets and API tokens.
+# Leave empty to fall back to JWT_SECRET_KEY, or set a distinct random value with f619a2942a188928414afd7e97fc6072c1c21905a723301749f13150bdd57612.
+APP_ENCRYPTION_KEY=
 
 # Access Token 生命周期（分钟），默认 15
 ACCESS_TOKEN_LIFETIME_MINUTES=15

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ GEMINI.md
 .tools/
 .wrangler/
 .zread/
+
+fix.sh

--- a/packages/server/cmd/init/main.go
+++ b/packages/server/cmd/init/main.go
@@ -83,6 +83,7 @@ func main() {
 			appEncryptionKey := utils.GenerateRandomSHA256()
 			envExampleFile = bytes.ReplaceAll(envExampleFile, []byte("JWT_SECRET_KEY=replace-with-a-strong-secret"), []byte("JWT_SECRET_KEY="+jwtSecretKey))
 			envExampleFile = bytes.ReplaceAll(envExampleFile, []byte("APP_ENCRYPTION_KEY=replace-with-a-strong-secret"), []byte("APP_ENCRYPTION_KEY="+appEncryptionKey))
+			envExampleFile = bytes.ReplaceAll(envExampleFile, []byte("\nAPP_ENCRYPTION_KEY=\n"), []byte("\nAPP_ENCRYPTION_KEY="+appEncryptionKey+"\n"))
 			err = os.WriteFile(envPath, envExampleFile, 0644)
 			if err != nil {
 				log.Fatalf("替换 JWT_SECRET_KEY 失败: %v", err)

--- a/packages/server/cmd/server/main.go
+++ b/packages/server/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 	"g.co1d.in/Coldin04/Cyime/server/internal/database"
 	"g.co1d.in/Coldin04/Cyime/server/internal/media"
 	"g.co1d.in/Coldin04/Cyime/server/internal/middleware"
+	"g.co1d.in/Coldin04/Cyime/server/internal/securevalue"
 	"g.co1d.in/Coldin04/Cyime/server/internal/user"
 	"g.co1d.in/Coldin04/Cyime/server/internal/workspace"
 	"github.com/gofiber/fiber/v2"
@@ -23,10 +24,14 @@ func main() {
 	_ = config.LoadDotEnv(".env")
 
 	// Validate critical secrets BEFORE touching the database. If JWT_SECRET_KEY
-	// is missing, weak, or set to a known insecure default, refuse to start so
-	// the operator notices instead of silently shipping forgeable tokens.
+	// or APP_ENCRYPTION_KEY is missing, weak, or set to a known insecure
+	// default, refuse to start so the operator notices instead of silently
+	// shipping forgeable tokens or encrypting stored secrets with a public key.
 	if _, err := auth.LoadJWTSecret(); err != nil {
 		log.Fatalf("Auth configuration invalid: %v", err)
+	}
+	if err := securevalue.ValidateEncryptionKey(); err != nil {
+		log.Fatalf("Encryption configuration invalid: %v", err)
 	}
 
 	// Initialize database

--- a/packages/server/internal/acl/service.go
+++ b/packages/server/internal/acl/service.go
@@ -144,6 +144,9 @@ func RoleAllowsAction(role, action string) bool {
 func AllowedRolesForAction(action string) []string {
 	switch action {
 	case ActionRead:
+		if !config.GetCollaborationEnabled() {
+			return []string{RoleOwner}
+		}
 		return []string{RoleViewer, RoleEditor, RoleCollaborator, RoleOwner}
 	case ActionEdit:
 		if !config.GetCollaborationEnabled() {

--- a/packages/server/internal/media/service_test.go
+++ b/packages/server/internal/media/service_test.go
@@ -884,3 +884,47 @@ func TestListOwnedAssets_PaginatesLikeWorkspaceList(t *testing.T) {
 		t.Fatalf("expected hasMore=false at offset 1 limit 2, got true")
 	}
 }
+
+func TestGetAccessibleAsset_DeniesSharedPermissionWhenCollaborationDisabled(t *testing.T) {
+	db := setupMediaTestDB(t)
+	ownerID := uuid.New()
+	viewerID := uuid.New()
+	docID := seedOwnedDocument(t, db, ownerID)
+	seedDocumentPermission(t, db, docID, viewerID, ownerID, "viewer")
+	t.Setenv("COLLABORATION_ENABLED", "false")
+
+	blob := seedBlob(t, db, "owner/disabled-collab.png", "image/png", 17, "hash-disabled-collab")
+	asset := models.Asset{
+		ID:             uuid.New(),
+		OwnerUserID:    ownerID,
+		DocumentID:     &docID,
+		BlobID:         blob.ID,
+		Kind:           "image",
+		Filename:       "disabled-collab.png",
+		URL:            blob.URL,
+		Visibility:     "private",
+		Status:         "ready",
+		ReferenceCount: 1,
+		CreatedBy:      ownerID,
+	}
+	if err := db.Create(&asset).Error; err != nil {
+		t.Fatalf("create asset: %v", err)
+	}
+	if err := db.Create(&models.DocumentAssetRef{
+		ID:          uuid.New(),
+		DocumentID:  docID,
+		AssetID:     asset.ID,
+		OwnerUserID: ownerID,
+		RefType:     mediaRefTypeEditorContent,
+	}).Error; err != nil {
+		t.Fatalf("create ref: %v", err)
+	}
+
+	if _, err := GetAccessibleAsset(viewerID, asset.ID); !errors.Is(err, ErrAssetNotFoundOrForbidden) {
+		t.Fatalf("expected shared viewer access to be denied when collaboration is disabled, got %v", err)
+	}
+
+	if _, err := GetAccessibleAsset(ownerID, asset.ID); err != nil {
+		t.Fatalf("expected owner access to remain allowed when collaboration is disabled: %v", err)
+	}
+}

--- a/packages/server/internal/media/service_test.go
+++ b/packages/server/internal/media/service_test.go
@@ -24,7 +24,7 @@ import (
 
 func setupMediaTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	t.Setenv("APP_ENCRYPTION_KEY", "test-app-encryption-key")
+	t.Setenv("APP_ENCRYPTION_KEY", "f3a4d6e7c1b2a8d9e0f1a2b3c4d5e6f70a1b2c3d")
 	// Keep tests deterministic: avoid async thumbnail writes racing on SQLite locks.
 	t.Setenv("MEDIA_THUMBNAIL_SOURCE_MAX_BYTES", "1")
 	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", uuid.NewString())

--- a/packages/server/internal/securevalue/securevalue.go
+++ b/packages/server/internal/securevalue/securevalue.go
@@ -7,12 +7,16 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
 )
 
-const encryptedValuePrefix = "enc:v1:"
+const (
+	encryptedValuePrefix = "enc:v1:"
+	minSecretLength      = 32
+)
 
 // EncryptedValuePrefix is the prefix used for encrypted values stored in the database.
 const EncryptedValuePrefix = encryptedValuePrefix
@@ -20,6 +24,14 @@ const EncryptedValuePrefix = encryptedValuePrefix
 // ErrInvalidFormat is returned by DecryptString when the input is not a valid
 // encrypted value (e.g. plaintext stored before encryption was introduced).
 var ErrInvalidFormat = errors.New("invalid encrypted value format")
+
+var insecureSecretBlocklist = map[string]struct{}{
+	"insecure-default-secret-for-dev-only": {},
+	"replace-with-a-strong-secret":         {},
+	"change-me":                            {},
+	"changeme":                             {},
+	"secret":                               {},
+}
 
 func EncryptString(plaintext string) (string, error) {
 	key, err := loadKey()
@@ -88,15 +100,35 @@ func DecryptString(encrypted string) (string, error) {
 	return string(plaintext), nil
 }
 
+func ValidateEncryptionKey() error {
+	_, err := loadKey()
+	return err
+}
+
 func loadKey() ([]byte, error) {
-	secret := strings.TrimSpace(os.Getenv("APP_ENCRYPTION_KEY"))
+	secretName := "APP_ENCRYPTION_KEY"
+	secret := strings.TrimSpace(os.Getenv(secretName))
 	if secret == "" {
-		secret = strings.TrimSpace(os.Getenv("JWT_SECRET_KEY"))
+		secretName = "JWT_SECRET_KEY"
+		secret = strings.TrimSpace(os.Getenv(secretName))
 	}
 	if secret == "" {
 		return nil, errors.New("missing APP_ENCRYPTION_KEY (or JWT_SECRET_KEY fallback)")
 	}
+	if err := validateSecret(secretName, secret); err != nil {
+		return nil, err
+	}
 
 	sum := sha256.Sum256([]byte(secret))
 	return sum[:], nil
+}
+
+func validateSecret(name, secret string) error {
+	if _, blocked := insecureSecretBlocklist[strings.ToLower(secret)]; blocked {
+		return fmt.Errorf("%s is set to a known insecure default; generate a strong random secret with 5619a079a803a895e1ced94f5a759dd12dd3df7c06a9355c11c12ed9805b6da9", name)
+	}
+	if len(secret) < minSecretLength {
+		return fmt.Errorf("%s must be at least %d characters long (got %d); generate one with 45d80dcef35bf1009602b9baa57c091daa5a307f3f275b7f510f6df18c2475bb", name, minSecretLength, len(secret))
+	}
+	return nil
 }

--- a/packages/server/internal/securevalue/securevalue_test.go
+++ b/packages/server/internal/securevalue/securevalue_test.go
@@ -1,9 +1,14 @@
 package securevalue
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+const strongEncryptionKey = "f3a4d6e7c1b2a8d9e0f1a2b3c4d5e6f70a1b2c3d"
 
 func TestEncryptDecryptString_RoundTrip(t *testing.T) {
-	t.Setenv("APP_ENCRYPTION_KEY", "test-app-encryption-key")
+	t.Setenv("APP_ENCRYPTION_KEY", strongEncryptionKey)
 
 	encrypted, err := EncryptString("secret-value")
 	if err != nil {
@@ -23,9 +28,44 @@ func TestEncryptDecryptString_RoundTrip(t *testing.T) {
 }
 
 func TestDecryptString_RejectsInvalidFormat(t *testing.T) {
-	t.Setenv("APP_ENCRYPTION_KEY", "test-app-encryption-key")
+	t.Setenv("APP_ENCRYPTION_KEY", strongEncryptionKey)
 
 	if _, err := DecryptString("plain-text"); err == nil {
 		t.Fatalf("expected invalid format error")
+	}
+}
+
+func TestValidateEncryptionKey_RejectsKnownDefaultAppKey(t *testing.T) {
+	t.Setenv("APP_ENCRYPTION_KEY", "replace-with-a-strong-secret")
+	t.Setenv("JWT_SECRET_KEY", strongEncryptionKey)
+
+	err := ValidateEncryptionKey()
+	if err == nil {
+		t.Fatal("expected known default APP_ENCRYPTION_KEY to be rejected")
+	}
+	if !strings.Contains(err.Error(), "insecure default") {
+		t.Fatalf("expected insecure default error, got %v", err)
+	}
+}
+
+func TestValidateEncryptionKey_RejectsShortAppKey(t *testing.T) {
+	t.Setenv("APP_ENCRYPTION_KEY", "short-secret")
+	t.Setenv("JWT_SECRET_KEY", strongEncryptionKey)
+
+	err := ValidateEncryptionKey()
+	if err == nil {
+		t.Fatal("expected short APP_ENCRYPTION_KEY to be rejected")
+	}
+	if !strings.Contains(err.Error(), "at least") {
+		t.Fatalf("expected length error, got %v", err)
+	}
+}
+
+func TestValidateEncryptionKey_FallsBackToStrongJWTSecret(t *testing.T) {
+	t.Setenv("APP_ENCRYPTION_KEY", "")
+	t.Setenv("JWT_SECRET_KEY", strongEncryptionKey)
+
+	if err := ValidateEncryptionKey(); err != nil {
+		t.Fatalf("unexpected fallback validation error: %v", err)
 	}
 }

--- a/packages/server/internal/user/handler_test.go
+++ b/packages/server/internal/user/handler_test.go
@@ -24,7 +24,7 @@ import (
 
 func setupUserTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	t.Setenv("APP_ENCRYPTION_KEY", "test-app-encryption-key")
+	t.Setenv("APP_ENCRYPTION_KEY", "f3a4d6e7c1b2a8d9e0f1a2b3c4d5e6f70a1b2c3d")
 	dsn := "file:" + uuid.NewString() + "?mode=memory&cache=shared"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	if err != nil {

--- a/packages/server/internal/workspace/search_test.go
+++ b/packages/server/internal/workspace/search_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -176,6 +177,33 @@ func TestSearchWorkspace_MultiKeywordMediaMatchesAcrossTerms(t *testing.T) {
 	}
 	if len(result.Media) != 1 {
 		t.Fatalf("expected multi-keyword media hit, got %+v", result.Media)
+	}
+}
+
+func TestSearchWorkspace_LimitsLongMultiKeywordQueries(t *testing.T) {
+	db := setupWorkspaceTestDB(t)
+	userID := uuid.New()
+	_ = seedDocumentForWorkspace(t, db, userID, "普通标题")
+
+	terms := make([]string, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		terms = append(terms, fmt.Sprintf("term%04d", i))
+	}
+	query := strings.Join(terms, " ")
+
+	if got := tokenizeSearchTerms(query); len(got) != maxSearchTerms {
+		t.Fatalf("expected tokenized terms to be capped at %d, got %d", maxSearchTerms, len(got))
+	}
+	if got := len([]rune(normalizeSearchQuery(query))); got > maxSearchQueryRunes {
+		t.Fatalf("expected normalized query to be capped at %d runes, got %d", maxSearchQueryRunes, got)
+	}
+
+	result, err := SearchWorkspace(userID, query, 5)
+	if err != nil {
+		t.Fatalf("search workspace with many terms should not build an oversized SQL expression: %v", err)
+	}
+	if result.Query != normalizeSearchQuery(query) {
+		t.Fatalf("expected returned query to be normalized, got %q", result.Query)
 	}
 }
 

--- a/packages/server/internal/workspace/service.go
+++ b/packages/server/internal/workspace/service.go
@@ -454,6 +454,11 @@ func GetSharedDocumentSummary(userID uuid.UUID) (*SharedDocumentSummaryResponse,
 	}
 }
 
+const (
+	maxSearchQueryRunes = 256
+	maxSearchTerms      = 8
+)
+
 func normalizeSearchLimit(limit int) int {
 	if limit <= 0 {
 		return 5
@@ -464,8 +469,17 @@ func normalizeSearchLimit(limit int) int {
 	return limit
 }
 
-func tokenizeSearchTerms(query string) []string {
+func normalizeSearchQuery(query string) string {
 	trimmed := strings.TrimSpace(query)
+	runes := []rune(trimmed)
+	if len(runes) <= maxSearchQueryRunes {
+		return trimmed
+	}
+	return strings.TrimSpace(string(runes[:maxSearchQueryRunes]))
+}
+
+func tokenizeSearchTerms(query string) []string {
+	trimmed := normalizeSearchQuery(query)
 	if trimmed == "" {
 		return nil
 	}
@@ -475,8 +489,8 @@ func tokenizeSearchTerms(query string) []string {
 		rawTerms = []string{trimmed}
 	}
 
-	seen := make(map[string]struct{}, len(rawTerms))
-	terms := make([]string, 0, len(rawTerms))
+	seen := make(map[string]struct{}, min(len(rawTerms), maxSearchTerms))
+	terms := make([]string, 0, min(len(rawTerms), maxSearchTerms))
 	for _, term := range rawTerms {
 		normalized := strings.TrimSpace(term)
 		if normalized == "" {
@@ -488,6 +502,9 @@ func tokenizeSearchTerms(query string) []string {
 		}
 		seen[key] = struct{}{}
 		terms = append(terms, normalized)
+		if len(terms) >= maxSearchTerms {
+			break
+		}
 	}
 	return terms
 }
@@ -878,7 +895,7 @@ func applyMultiKeywordLike(query *gorm.DB, terms []string, fields []string) *gor
 }
 
 func SearchWorkspace(userID uuid.UUID, rawQuery string, limit int) (*SearchResponse, error) {
-	query := strings.TrimSpace(rawQuery)
+	query := normalizeSearchQuery(rawQuery)
 	limit = normalizeSearchLimit(limit)
 
 	result := &SearchResponse{


### PR DESCRIPTION
This pull request introduces important security and robustness improvements to secret key management, enforces stricter validation for encryption keys, and adds safeguards and tests for workspace search and collaboration permissions. The most significant changes are grouped below:

**Security and Secret Key Management:**

* Enforces strong validation for `APP_ENCRYPTION_KEY` and `JWT_SECRET_KEY`, rejecting known insecure defaults and keys shorter than 32 characters. The server now refuses to start if these requirements are not met, ensuring stored secrets and tokens are not protected by weak or default values. (`packages/server/internal/securevalue/securevalue.go`, `packages/server/cmd/server/main.go`, `.env.example`) [[1]](diffhunk://#diff-c869043e481f7c968da8543bcbdbd5ff890df5678a018107efa34717a3e081f7R28-R35) [[2]](diffhunk://#diff-c869043e481f7c968da8543bcbdbd5ff890df5678a018107efa34717a3e081f7R103-R134) [[3]](diffhunk://#diff-3cede0c936eb086f6085905328f2327f08c1e15158c9010d7b3e7beb3c0c62f1L26-R35) [[4]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL15-R17)
* Adds comprehensive tests to verify secret key validation, including fallback behavior and error reporting for insecure or short keys. (`packages/server/internal/securevalue/securevalue_test.go`)

**Configuration and Initialization:**

* Updates the `.env.example` to clarify the purpose of `APP_ENCRYPTION_KEY`, make it empty by default, and document fallback and generation instructions. The initialization script now correctly populates the key in both legacy and new formats. (`.env.example`, `packages/server/cmd/init/main.go`) [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL15-R17) [[2]](diffhunk://#diff-5a60cb5942aec522990fbcb2ad52487f3996a763d10382e91286816b0d28540cR86)

**Collaboration and Access Control:**

* Restricts document asset access: when collaboration is disabled, only the owner can access assets, regardless of shared permissions. Includes a new test to verify this behavior. (`packages/server/internal/acl/service.go`, `packages/server/internal/media/service_test.go`) [[1]](diffhunk://#diff-11290353a97d9d2f6ba2c03a27d6ab5844c845223ec77670b4cacd413e658ff8R147-R149) [[2]](diffhunk://#diff-725f7137d8a38f58d263203eed20e0b8df475e400328df7f411562a3cd15d6dbR887-R930)

**Workspace Search Robustness:**

* Adds limits to workspace search queries: maximum of 256 runes per query and up to 8 search terms, preventing oversized SQL expressions and improving system stability. Includes tests to verify these constraints. (`packages/server/internal/workspace/service.go`, `packages/server/internal/workspace/search_test.go`) [[1]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9R457-R461) [[2]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9L467-R482) [[3]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9L478-R493) [[4]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9R505-R507) [[5]](diffhunk://#diff-625250d96c900c82604a13f45a9c27d234bc0d9dcc5732fc0337f0b04a0c76b9L881-R898) [[6]](diffhunk://#diff-dbf3220e541ef0988b3dd207c310d9a4e95a9c57a0700928e217e68bd7064053R183-R209)

**Test Improvements:**

* Updates test fixtures and helpers to use a strong encryption key, ensuring all encryption-related tests are deterministic and secure. (`packages/server/internal/media/service_test.go`, `packages/server/internal/user/handler_test.go`, `packages/server/internal/securevalue/securevalue_test.go`) [[1]](diffhunk://#diff-725f7137d8a38f58d263203eed20e0b8df475e400328df7f411562a3cd15d6dbL27-R27) [[2]](diffhunk://#diff-3556a92213d0da339ac39e80188b697bc562f856000180e9667fba08fecee382L27-R27) [[3]](diffhunk://#diff-7aa924c2b6f073ceb72085af66b229f3e4664b1ec235b8df49e29e75bf886039L3-R11)

These changes collectively harden the application's security posture, enforce best practices for secret management, and make the workspace search and collaboration features more robust.