### PR TITLE
fix(init): secure generated env secrets

### DIFF
--- a/packages/server/cmd/init/main.go
+++ b/packages/server/cmd/init/main.go
@@ -73,19 +73,26 @@ func main() {
 			if err != nil {
 				log.Fatalf("读取 .env.example 失败: %v, 请通过原始 ENV 获取一份 ENV 样本后重试流程!", err)
 			}
-			err = os.WriteFile(envPath, envExampleFile, 0644)
+			// replace the JWT_SECRET_KEY with a random SHA256 hash
+			jwtSecretKey, err := utils.GenerateRandomSHA256()
 			if err != nil {
-				log.Fatalf("创建 .env 失败: %v", err)
+				log.Fatalf("生成 JWT_SECRET_KEY 失败: %v", err)
 				return
 			}
-			// replace the JWT_SECRET_KEY with a random SHA256 hash
-			jwtSecretKey := utils.GenerateRandomSHA256()
-			appEncryptionKey := utils.GenerateRandomSHA256()
+			appEncryptionKey, err := utils.GenerateRandomSHA256()
+			if err != nil {
+				log.Fatalf("生成 APP_ENCRYPTION_KEY 失败: %v", err)
+				return
+			}
 			envExampleFile = bytes.ReplaceAll(envExampleFile, []byte("JWT_SECRET_KEY=replace-with-a-strong-secret"), []byte("JWT_SECRET_KEY="+jwtSecretKey))
 			envExampleFile = bytes.ReplaceAll(envExampleFile, []byte("APP_ENCRYPTION_KEY=replace-with-a-strong-secret"), []byte("APP_ENCRYPTION_KEY="+appEncryptionKey))
-			err = os.WriteFile(envPath, envExampleFile, 0644)
+			err = os.WriteFile(envPath, envExampleFile, 0600)
 			if err != nil {
 				log.Fatalf("替换 JWT_SECRET_KEY 失败: %v", err)
+				return
+			}
+			if err := os.Chmod(envPath, 0600); err != nil {
+				log.Fatalf("设置 .env 权限失败: %v", err)
 				return
 			}
 			fmt.Println("已创建 .env 文件")

--- a/packages/server/internal/utils/sha256_generator.go
+++ b/packages/server/internal/utils/sha256_generator.go
@@ -5,13 +5,16 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 )
 
 // GenerateRandomSHA256 returns a hex-encoded random SHA256 hash string.
 // It generates 32 random bytes and returns their SHA256 hex digest.
-func GenerateRandomSHA256() string {
+func GenerateRandomSHA256() (string, error) {
 	randomBytes := make([]byte, 32)
-	rand.Read(randomBytes)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", fmt.Errorf("generate random bytes: %w", err)
+	}
 	sum := sha256.Sum256(randomBytes)
-	return hex.EncodeToString(sum[:])
+	return hex.EncodeToString(sum[:]), nil
 }


### PR DESCRIPTION
### Motivation
- Prevent exposing generated JWT and app encryption secrets by avoiding a world-readable `.env` file during development fallback.
- Ensure cryptographic randomness failures are detected instead of silently producing weak secrets.

### Description
- Change `GenerateRandomSHA256` to return `(string, error)` and propagate `rand.Read` errors from `packages/server/internal/utils/sha256_generator.go`.
- Generate `JWT_SECRET_KEY` and `APP_ENCRYPTION_KEY` in memory before writing and replace placeholders in the template in `packages/server/cmd/init/main.go`.
- Write the generated `.env` with mode `0600` and call `os.Chmod(..., 0600)` to ensure owner-only file permissions.
- Add error handling around secret generation and file permission setting so failures abort initialization with clear messages.

### Testing
- Ran `go test ./cmd/init ./internal/utils`, which completed successfully (packages contain no test files but compiled).
- Ran `go test ./...`, which exercised the repository and reported unrelated existing test failures in `internal/auth` and `internal/media` packages; the changes compile and do not introduce those failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fe7fc80e48832ba568a5fd83b0b0ec)