### PR TITLE
Fix and sync lazy load for workspace export workflow

### DIFF
--- a/packages/web/src/lib/components/workspace/DocumentListItem.svelte
+++ b/packages/web/src/lib/components/workspace/DocumentListItem.svelte
@@ -36,17 +36,12 @@
 	} from '$lib/api/editor';
 	import type { ExportAction } from '$lib/export/exportActions';
 	import { exportActionRequiresPublicImageURLs } from '$lib/export/exportActions';
-	import { collectManagedImages } from '$lib/export/exportPrivateImages';
-	import {
-		createExportCopyTitle,
-		normalizeManagedImagesForSave,
-		performDocumentExport,
-		prepareExportContentWithPublicImages,
-		resolveExportErrorMessage
-	} from '$lib/export/documentExportWorkflow';
+	import { collectManagedImages } from '$lib/export/managedImages';
 	import { clickOutside } from '$lib/actions/clickOutside';
 	import * as m from '$paraglide/messages';
 	import { getLocale } from '$paraglide/runtime';
+
+	type DocumentExportWorkflow = typeof import('$lib/export/documentExportWorkflow');
 
 	let {
 		item,
@@ -122,6 +117,7 @@
 	const menuStyle = $derived(
 		menuPlacement === 'context' ? `left: ${contextMenuX}px; top: ${contextMenuY}px;` : ''
 	);
+	let documentExportWorkflowPromise: Promise<DocumentExportWorkflow> | null = null;
 
 	$effect(() => {
 		documentTitle = item.title || '';
@@ -133,6 +129,20 @@
 		documentPublicUrl = item.publicUrl || '';
 		documentRole = item.myRole || 'owner';
 	});
+
+	function loadDocumentExportWorkflow(): Promise<DocumentExportWorkflow> {
+		documentExportWorkflowPromise ??= import('$lib/export/documentExportWorkflow');
+		return documentExportWorkflowPromise;
+	}
+
+	async function resolveWorkspaceExportErrorMessage(error: unknown): Promise<string> {
+		try {
+			const workflow = await loadDocumentExportWorkflow();
+			return workflow.resolveExportErrorMessage(error);
+		} catch {
+			return error instanceof Error && error.message.trim() !== '' ? error.message : m.editor_export_failed();
+		}
+	}
 
 	function formatRelativeTime(dateString: string): string {
 		const date = new Date(dateString);
@@ -390,7 +400,8 @@
 		pendingExportAction = null;
 		pendingExportContent = null;
 		exportTargetId = '';
-		await performDocumentExport({
+		const workflow = await loadDocumentExportWorkflow();
+		await workflow.performDocumentExport({
 			action,
 			title: documentTitle,
 			contentJson: exportContent,
@@ -406,15 +417,16 @@
 			if (!pendingExportContent) {
 				throw new Error('Missing export content');
 			}
-			const exportContent = await prepareExportContentWithPublicImages({
+			const workflow = await loadDocumentExportWorkflow();
+			const exportContent = await workflow.prepareExportContentWithPublicImages({
 				documentId: item.id,
 				contentJson: pendingExportContent,
 				targetId: exportTargetId,
 				toastId: 'workspace-export-private-images'
 			});
 			await createDocument({
-				title: createExportCopyTitle(documentTitle),
-				contentJson: normalizeManagedImagesForSave(exportContent) as { [key: string]: unknown },
+				title: workflow.createExportCopyTitle(documentTitle),
+				contentJson: workflow.normalizeManagedImagesForSave(exportContent) as { [key: string]: unknown },
 				folderId: item.folderId ?? null,
 				documentType: documentType === 'table' ? 'table' : 'rich_text',
 				preferredImageTargetId: exportTargetId
@@ -423,7 +435,7 @@
 			await finalizeExportWithProcessedContent(exportContent);
 		} catch (error) {
 			console.error('[Workspace Export] Failed to create export copy:', error);
-			toast.error(resolveExportErrorMessage(error));
+			toast.error(await resolveWorkspaceExportErrorMessage(error));
 		} finally {
 			isPreparingExport = false;
 		}
@@ -437,20 +449,21 @@
 			if (!pendingExportContent) {
 				throw new Error('Missing export content');
 			}
-			const exportContent = await prepareExportContentWithPublicImages({
+			const workflow = await loadDocumentExportWorkflow();
+			const exportContent = await workflow.prepareExportContentWithPublicImages({
 				documentId: item.id,
 				contentJson: pendingExportContent,
 				targetId: exportTargetId,
 				toastId: 'workspace-export-private-images'
 			});
-			await updateDocumentContent(item.id, normalizeManagedImagesForSave(exportContent));
+			await updateDocumentContent(item.id, workflow.normalizeManagedImagesForSave(exportContent));
 			const targetResult = await updateDocumentImageTarget(item.id, exportTargetId);
 			documentPreferredImageTargetId = targetResult.preferredImageTargetId;
 			onRefresh?.();
 			await finalizeExportWithProcessedContent(exportContent);
 		} catch (error) {
 			console.error('[Workspace Export] Failed to replace private images for export:', error);
-			toast.error(resolveExportErrorMessage(error));
+			toast.error(await resolveWorkspaceExportErrorMessage(error));
 		} finally {
 			isPreparingExport = false;
 		}
@@ -467,7 +480,8 @@
 			const managedImages = collectManagedImages(exportContent);
 
 			if (!exportActionRequiresPublicImageURLs(action) || managedImages.length === 0) {
-				await performDocumentExport({
+				const workflow = await loadDocumentExportWorkflow();
+				await workflow.performDocumentExport({
 					action,
 					title: documentTitle,
 					contentJson: exportContent,

--- a/packages/web/src/lib/components/workspace/DocumentListItem.svelte
+++ b/packages/web/src/lib/components/workspace/DocumentListItem.svelte
@@ -131,7 +131,13 @@
 	});
 
 	function loadDocumentExportWorkflow(): Promise<DocumentExportWorkflow> {
-		documentExportWorkflowPromise ??= import('$lib/export/documentExportWorkflow');
+		if (!documentExportWorkflowPromise) {
+			documentExportWorkflowPromise = import('$lib/export/documentExportWorkflow').catch((error) => {
+				documentExportWorkflowPromise = null;
+				throw error;
+			});
+		}
+
 		return documentExportWorkflowPromise;
 	}
 

--- a/packages/web/src/lib/export/documentExportWorkflow.ts
+++ b/packages/web/src/lib/export/documentExportWorkflow.ts
@@ -5,39 +5,22 @@ import type { ExportAction } from '$lib/export/exportActions';
 import {
 	buildExportAssetFilename,
 	cloneContentJson,
-	collectImageNodes,
 	collectManagedImages,
+	inferExportAssetMimeType,
+	normalizeManagedImagesForSave,
+	replaceManagedImagesWithPublicURLs
+} from '$lib/export/managedImages';
+import {
 	ExportCopyError,
 	exportHtmlDocument,
 	exportPdfDocument,
-	getManagedAssetId,
-	inferExportAssetMimeType,
 	inlineManagedImagesAsDataURLs,
-	replaceManagedImagesWithPublicURLs,
 	runExportAction
 } from '$lib/export/exportPrivateImages';
 import { toast } from 'svelte-sonner';
 import * as m from '$paraglide/messages';
 
-type ImageNodeRecord = Record<string, unknown> & {
-	attrs?: Record<string, unknown>;
-};
-
-export function normalizeManagedImagesForSave(input: JSONContent): JSONContent {
-	const cloned = cloneContentJson(input);
-	const imageNodes: ImageNodeRecord[] = [];
-	collectImageNodes(cloned, imageNodes);
-
-	for (const node of imageNodes) {
-		const attrs = (node.attrs ?? {}) as Record<string, unknown>;
-		const assetId = getManagedAssetId(attrs);
-		if (!assetId) continue;
-		delete attrs.src;
-		node.attrs = attrs;
-	}
-
-	return cloned;
-}
+export { normalizeManagedImagesForSave };
 
 export function createExportCopyTitle(value: string): string {
 	const trimmed = value.trim();

--- a/packages/web/src/lib/export/exportPrivateImages.ts
+++ b/packages/web/src/lib/export/exportPrivateImages.ts
@@ -7,18 +7,11 @@ import {
 	exportMarkdown
 } from '$lib/export/documentExport';
 import type { ExportAction } from '$lib/export/exportActions';
-
-type ImageNodeRecord = Record<string, unknown> & {
-	attrs?: Record<string, unknown>;
-	content?: unknown[];
-};
-
-export type ManagedImageUsage = {
-	assetId: string;
-	src: string | null;
-	title: string | null;
-	alt: string | null;
-};
+import {
+	cloneContentJson,
+	collectManagedImages,
+	replaceManagedImagesWithPublicURLs
+} from '$lib/export/managedImages';
 
 export class ExportCopyError extends Error {
 	content: string;
@@ -30,176 +23,10 @@ export class ExportCopyError extends Error {
 	}
 }
 
-export function cloneContentJson(value: JSONContent): JSONContent {
-	return JSON.parse(JSON.stringify(value)) as JSONContent;
-}
-
-export function collectImageNodes(value: unknown, nodes: ImageNodeRecord[]) {
-	if (!value || typeof value !== 'object') {
-		return;
-	}
-
-	const node = value as ImageNodeRecord;
-	if (node.type === 'image') {
-		nodes.push(node);
-	}
-
-	const children = node.content;
-	if (Array.isArray(children)) {
-		for (const child of children) {
-			collectImageNodes(child, nodes);
-		}
-	}
-}
-
-export function getManagedAssetId(attrs: Record<string, unknown>): string | null {
-	const raw = attrs.assetId;
-	return typeof raw === 'string' && raw.trim() !== '' ? raw.trim() : null;
-}
-
-export function collectManagedImages(content: JSONContent): ManagedImageUsage[] {
-	const imageNodes: ImageNodeRecord[] = [];
-	collectImageNodes(content, imageNodes);
-
-	const usages: ManagedImageUsage[] = [];
-	const seen = new Set<string>();
-	for (const node of imageNodes) {
-		const attrs = (node.attrs ?? {}) as Record<string, unknown>;
-		const assetId = getManagedAssetId(attrs);
-		if (!assetId || seen.has(assetId)) {
-			continue;
-		}
-
-		seen.add(assetId);
-		usages.push({
-			assetId,
-			src: typeof attrs.src === 'string' && attrs.src.trim() !== '' ? attrs.src.trim() : null,
-			title: typeof attrs.title === 'string' && attrs.title.trim() !== '' ? attrs.title.trim() : null,
-			alt: typeof attrs.alt === 'string' && attrs.alt.trim() !== '' ? attrs.alt.trim() : null
-		});
-	}
-
-	return usages;
-}
-
-export function replaceManagedImagesWithPublicURLs(
-	content: JSONContent,
-	publicURLByAssetID: Map<string, string>
-): JSONContent {
-	const cloned = cloneContentJson(content);
-	const imageNodes: ImageNodeRecord[] = [];
-	collectImageNodes(cloned, imageNodes);
-
-	for (const node of imageNodes) {
-		const attrs = (node.attrs ?? {}) as Record<string, unknown>;
-		const assetId = getManagedAssetId(attrs);
-		if (!assetId) {
-			continue;
-		}
-
-		const publicURL = publicURLByAssetID.get(assetId);
-		if (!publicURL) {
-			continue;
-		}
-
-		attrs.src = publicURL;
-		delete attrs.assetId;
-		node.attrs = attrs;
-	}
-
-	return cloned;
-}
-
 export function buildExportFilename(title: string, extension: 'html' | 'md'): string {
 	const rawTitle = title.trim();
 	const safeTitle = rawTitle.replace(/[\\/:*?"<>|]+/g, ' ').replace(/\s+/g, ' ').trim();
 	return `${safeTitle || 'cyimewrite-export'}.${extension}`;
-}
-
-export function buildExportAssetFilename(
-	assetId: string,
-	mimeType: string,
-	fallbackLabel?: string | null
-): string {
-	const rawLabel = (fallbackLabel ?? '').trim() || `asset-${assetId}`;
-	const safeLabel = rawLabel.replace(/[\\/:*?"<>|]+/g, ' ').replace(/\s+/g, ' ').trim();
-	const extension = resolveExportAssetExtension(mimeType, safeLabel);
-	const basename = stripExportAssetExtension(safeLabel || `asset-${assetId}`);
-	return `${basename || `asset-${assetId}`}.${extension}`;
-}
-
-export function inferExportAssetMimeType(
-	mimeType: string,
-	fallbackLabel?: string | null,
-	src?: string | null
-): string {
-	const normalized = normalizeMimeType(mimeType);
-	if (isSupportedExportImageMimeType(normalized)) {
-		return normalized;
-	}
-
-	const extension = getImageExtensionFromLabel(fallbackLabel) ?? getImageExtensionFromURL(src);
-	switch (extension) {
-		case 'png':
-			return 'image/png';
-		case 'jpg':
-		case 'jpeg':
-			return 'image/jpeg';
-		case 'webp':
-			return 'image/webp';
-		case 'gif':
-			return 'image/gif';
-		default:
-			return normalized || 'application/octet-stream';
-	}
-}
-
-function resolveExportAssetExtension(mimeType: string, fallbackLabel?: string | null): string {
-	const normalized = normalizeMimeType(mimeType);
-	switch (normalized) {
-		case 'image/png':
-			return 'png';
-		case 'image/jpeg':
-			return 'jpg';
-		case 'image/webp':
-			return 'webp';
-		case 'image/gif':
-			return 'gif';
-		default:
-			return getImageExtensionFromLabel(fallbackLabel) ?? 'bin';
-	}
-}
-
-function stripExportAssetExtension(value: string): string {
-	return value.replace(/\.(?:png|jpe?g|webp|gif|bin)$/i, '').trim();
-}
-
-function normalizeMimeType(value: string): string {
-	return value.split(';', 1)[0]?.trim().toLowerCase() ?? '';
-}
-
-function isSupportedExportImageMimeType(value: string): boolean {
-	return value === 'image/png' || value === 'image/jpeg' || value === 'image/webp' || value === 'image/gif';
-}
-
-function getImageExtensionFromLabel(value?: string | null): string | null {
-	const match = value?.trim().toLowerCase().match(/\.([a-z0-9]+)$/);
-	const extension = match?.[1] ?? '';
-	return extension === 'png' || extension === 'jpg' || extension === 'jpeg' || extension === 'webp' || extension === 'gif'
-		? extension
-		: null;
-}
-
-function getImageExtensionFromURL(value?: string | null): string | null {
-	if (!value) {
-		return null;
-	}
-	try {
-		const parsed = new URL(value);
-		return getImageExtensionFromLabel(parsed.pathname);
-	} catch {
-		return getImageExtensionFromLabel(value);
-	}
 }
 
 export async function runExportAction(action: ExportAction, options: {

--- a/packages/web/src/lib/export/managedImages.ts
+++ b/packages/web/src/lib/export/managedImages.ts
@@ -1,0 +1,195 @@
+import type { JSONContent } from '@tiptap/core';
+
+type ImageNodeRecord = Record<string, unknown> & {
+	attrs?: Record<string, unknown>;
+	content?: unknown[];
+};
+
+export type ManagedImageUsage = {
+	assetId: string;
+	src: string | null;
+	title: string | null;
+	alt: string | null;
+};
+
+export function cloneContentJson(value: JSONContent): JSONContent {
+	return JSON.parse(JSON.stringify(value)) as JSONContent;
+}
+
+export function collectImageNodes(value: unknown, nodes: ImageNodeRecord[]) {
+	if (!value || typeof value !== 'object') {
+		return;
+	}
+
+	const node = value as ImageNodeRecord;
+	if (node.type === 'image') {
+		nodes.push(node);
+	}
+
+	const children = node.content;
+	if (Array.isArray(children)) {
+		for (const child of children) {
+			collectImageNodes(child, nodes);
+		}
+	}
+}
+
+export function getManagedAssetId(attrs: Record<string, unknown>): string | null {
+	const raw = attrs.assetId;
+	return typeof raw === 'string' && raw.trim() !== '' ? raw.trim() : null;
+}
+
+export function collectManagedImages(content: JSONContent): ManagedImageUsage[] {
+	const imageNodes: ImageNodeRecord[] = [];
+	collectImageNodes(content, imageNodes);
+
+	const usages: ManagedImageUsage[] = [];
+	const seen = new Set<string>();
+	for (const node of imageNodes) {
+		const attrs = (node.attrs ?? {}) as Record<string, unknown>;
+		const assetId = getManagedAssetId(attrs);
+		if (!assetId || seen.has(assetId)) {
+			continue;
+		}
+
+		seen.add(assetId);
+		usages.push({
+			assetId,
+			src: typeof attrs.src === 'string' && attrs.src.trim() !== '' ? attrs.src.trim() : null,
+			title: typeof attrs.title === 'string' && attrs.title.trim() !== '' ? attrs.title.trim() : null,
+			alt: typeof attrs.alt === 'string' && attrs.alt.trim() !== '' ? attrs.alt.trim() : null
+		});
+	}
+
+	return usages;
+}
+
+export function replaceManagedImagesWithPublicURLs(
+	content: JSONContent,
+	publicURLByAssetID: Map<string, string>
+): JSONContent {
+	const cloned = cloneContentJson(content);
+	const imageNodes: ImageNodeRecord[] = [];
+	collectImageNodes(cloned, imageNodes);
+
+	for (const node of imageNodes) {
+		const attrs = (node.attrs ?? {}) as Record<string, unknown>;
+		const assetId = getManagedAssetId(attrs);
+		if (!assetId) {
+			continue;
+		}
+
+		const publicURL = publicURLByAssetID.get(assetId);
+		if (!publicURL) {
+			continue;
+		}
+
+		attrs.src = publicURL;
+		delete attrs.assetId;
+		node.attrs = attrs;
+	}
+
+	return cloned;
+}
+
+export function normalizeManagedImagesForSave(input: JSONContent): JSONContent {
+	const cloned = cloneContentJson(input);
+	const imageNodes: ImageNodeRecord[] = [];
+	collectImageNodes(cloned, imageNodes);
+
+	for (const node of imageNodes) {
+		const attrs = (node.attrs ?? {}) as Record<string, unknown>;
+		const assetId = getManagedAssetId(attrs);
+		if (!assetId) continue;
+		delete attrs.src;
+		node.attrs = attrs;
+	}
+
+	return cloned;
+}
+
+export function buildExportAssetFilename(
+	assetId: string,
+	mimeType: string,
+	fallbackLabel?: string | null
+): string {
+	const rawLabel = (fallbackLabel ?? '').trim() || `asset-${assetId}`;
+	const safeLabel = rawLabel.replace(/[\\/:*?"<>|]+/g, ' ').replace(/\s+/g, ' ').trim();
+	const extension = resolveExportAssetExtension(mimeType, safeLabel);
+	const basename = stripExportAssetExtension(safeLabel || `asset-${assetId}`);
+	return `${basename || `asset-${assetId}`}.${extension}`;
+}
+
+export function inferExportAssetMimeType(
+	mimeType: string,
+	fallbackLabel?: string | null,
+	src?: string | null
+): string {
+	const normalized = normalizeMimeType(mimeType);
+	if (isSupportedExportImageMimeType(normalized)) {
+		return normalized;
+	}
+
+	const extension = getImageExtensionFromLabel(fallbackLabel) ?? getImageExtensionFromURL(src);
+	switch (extension) {
+		case 'png':
+			return 'image/png';
+		case 'jpg':
+		case 'jpeg':
+			return 'image/jpeg';
+		case 'webp':
+			return 'image/webp';
+		case 'gif':
+			return 'image/gif';
+		default:
+			return normalized || 'application/octet-stream';
+	}
+}
+
+function resolveExportAssetExtension(mimeType: string, fallbackLabel?: string | null): string {
+	const normalized = normalizeMimeType(mimeType);
+	switch (normalized) {
+		case 'image/png':
+			return 'png';
+		case 'image/jpeg':
+			return 'jpg';
+		case 'image/webp':
+			return 'webp';
+		case 'image/gif':
+			return 'gif';
+		default:
+			return getImageExtensionFromLabel(fallbackLabel) ?? 'bin';
+	}
+}
+
+function stripExportAssetExtension(value: string): string {
+	return value.replace(/\.(?:png|jpe?g|webp|gif|bin)$/i, '').trim();
+}
+
+function normalizeMimeType(value: string): string {
+	return value.split(';', 1)[0]?.trim().toLowerCase() ?? '';
+}
+
+function isSupportedExportImageMimeType(value: string): boolean {
+	return value === 'image/png' || value === 'image/jpeg' || value === 'image/webp' || value === 'image/gif';
+}
+
+function getImageExtensionFromLabel(value?: string | null): string | null {
+	const match = value?.trim().toLowerCase().match(/\.([a-z0-9]+)$/);
+	const extension = match?.[1] ?? '';
+	return extension === 'png' || extension === 'jpg' || extension === 'jpeg' || extension === 'webp' || extension === 'gif'
+		? extension
+		: null;
+}
+
+function getImageExtensionFromURL(value?: string | null): string | null {
+	if (!value) {
+		return null;
+	}
+	try {
+		const parsed = new URL(value);
+		return getImageExtensionFromLabel(parsed.pathname);
+	} catch {
+		return getImageExtensionFromLabel(value);
+	}
+}

--- a/packages/web/src/routes/edit/documents/[id]/+page.svelte
+++ b/packages/web/src/routes/edit/documents/[id]/+page.svelte
@@ -45,13 +45,16 @@
 		collectImageNodes,
 		collectManagedImages,
 		cloneContentJson,
-		ExportCopyError,
-		exportPdfDocument,
-		exportHtmlDocument,
 		getManagedAssetId,
 		inferExportAssetMimeType,
+		normalizeManagedImagesForSave,
+		replaceManagedImagesWithPublicURLs
+	} from '$lib/export/managedImages';
+	import {
+		ExportCopyError,
+		exportHtmlDocument,
+		exportPdfDocument,
 		inlineManagedImagesAsDataURLs,
-		replaceManagedImagesWithPublicURLs,
 		runExportAction
 	} from '$lib/export/exportPrivateImages';
 	import { exportActionRequiresPublicImageURLs } from '$lib/export/exportActions';
@@ -207,25 +210,6 @@
 				continue;
 			}
 			attrs.src = resolvedURL;
-			node.attrs = attrs;
-		}
-
-		return cloned;
-	}
-
-	function normalizeManagedImagesForSave(input: JSONContent): JSONContent {
-		const cloned = cloneContentJson(input);
-		const imageNodes: ImageNodeRecord[] = [];
-		collectImageNodes(cloned, imageNodes);
-
-		for (const node of imageNodes) {
-			const attrs = (node.attrs ?? {}) as Record<string, unknown>;
-			const assetId = getManagedAssetId(attrs);
-			if (!assetId) {
-				continue;
-			}
-
-			delete attrs.src;
 			node.attrs = attrs;
 		}
 

--- a/packages/web/wrangler.toml
+++ b/packages/web/wrangler.toml
@@ -2,4 +2,4 @@ name = "cyimewrite-web"
 pages_build_output_dir = ".svelte-kit/cloudflare"
 compatibility_date = "2026-04-04"
 compatibility_flags = ["nodejs_compat"]
-upload_source_maps = true
+upload_source_maps = false


### PR DESCRIPTION
This pull request refactors the handling of managed image utilities for document export by moving all related functions into a new dedicated module, `managedImages.ts`. It updates all imports and usages across the codebase to use this new module, and cleans up duplicate or misplaced code. The refactor improves code organization, maintainability, and clarity, especially for image processing in document export workflows.

Key changes include:

**Managed Images Utilities Refactor:**

- All functions and types related to managing images in document content (such as `cloneContentJson`, `collectManagedImages`, `normalizeManagedImagesForSave`, `replaceManagedImagesWithPublicURLs`, and related helpers) have been moved from `exportPrivateImages.ts` and other locations into a new module, `managedImages.ts`. This centralizes image handling logic and eliminates duplication. [[1]](diffhunk://#diff-5e432e4c31cfe671296f1b56347984b4396c4e8b94f7fff633a89fb8f85693efR1-R195) [[2]](diffhunk://#diff-b6a5f6d566f5503dbc5b3dba5f090318831702cba5b78e1573b723e1abea6f49L10-R14) [[3]](diffhunk://#diff-b6a5f6d566f5503dbc5b3dba5f090318831702cba5b78e1573b723e1abea6f49L33-L204)

- Imports throughout the codebase have been updated to reference the new `managedImages.ts` module for image-related utilities, including in `documentExportWorkflow.ts`, `exportPrivateImages.ts`, and relevant Svelte components. ([packages/web/src/lib/export/documentExportWorkflow.tsL8-R23](diffhunk://#diff-8058cd2c0bbf83b27e1988ae134a1b3477ed815abacfd9b5b281e52ee7d6494fL8-R23), [packages/web/src/routes/edit/documents/[id]/+page.svelteL48-L54](diffhunk://#diff-1b2f8a9c69a142fd02d84f60a97ab312b3e55864f3eefbbc98e3f2ad266feeb5L48-L54))

**Document Export Workflow Updates:**

- The `DocumentListItem.svelte` component now lazily loads the `documentExportWorkflow` module for export actions, improving initial load performance and error handling. All calls to export workflow methods are now made through this dynamically imported module. [[1]](diffhunk://#diff-943add0c134f82ffd7fef136dbd14155380b04911ce6dee5ac56932bbc467434L39-R45) [[2]](diffhunk://#diff-943add0c134f82ffd7fef136dbd14155380b04911ce6dee5ac56932bbc467434R120) [[3]](diffhunk://#diff-943add0c134f82ffd7fef136dbd14155380b04911ce6dee5ac56932bbc467434R133-R146) [[4]](diffhunk://#diff-943add0c134f82ffd7fef136dbd14155380b04911ce6dee5ac56932bbc467434L393-R404) [[5]](diffhunk://#diff-943add0c134f82ffd7fef136dbd14155380b04911ce6dee5ac56932bbc467434L409-R429) [[6]](diffhunk://#diff-943add0c134f82ffd7fef136dbd14155380b04911ce6dee5ac56932bbc467434L426-R438) [[7]](diffhunk://#diff-943add0c134f82ffd7fef136dbd14155380b04911ce6dee5ac56932bbc467434L440-R466) [[8]](diffhunk://#diff-943add0c134f82ffd7fef136dbd14155380b04911ce6dee5ac56932bbc467434L470-R484)

**Code Cleanup and Removal of Duplicates:**

- Duplicate implementations of image normalization and related logic have been removed from individual Svelte files and other modules, in favor of the centralized utilities in `managedImages.ts`. ([packages/web/src/routes/edit/documents/[id]/+page.svelteL216-L234](diffhunk://#diff-1b2f8a9c69a142fd02d84f60a97ab312b3e55864f3eefbbc98e3f2ad266feeb5L216-L234), [[1]](diffhunk://#diff-8058cd2c0bbf83b27e1988ae134a1b3477ed815abacfd9b5b281e52ee7d6494fL8-R23) [[2]](diffhunk://#diff-b6a5f6d566f5503dbc5b3dba5f090318831702cba5b78e1573b723e1abea6f49L33-L204)

These changes significantly improve the modularity and maintainability of the codebase, especially for features involving managed images in document exports.