### PR TITLE
fix: bound recursive folder copy workload

### DIFF
--- a/packages/server/internal/workspace/handler.go
+++ b/packages/server/internal/workspace/handler.go
@@ -1251,7 +1251,8 @@ func UpdateDocumentTitleHandler(c *fiber.Ctx) error {
 				Error:   "Not Found",
 				Message: err.Error(),
 			})
-		case errors.Is(err, ErrDocumentTitleRequired), errors.Is(err, ErrDocumentTitleTooLong), errors.Is(err, ErrDuplicateDocumentTitle):
+		case errors.Is(err, ErrDocumentTitleRequired), errors.Is(err, ErrDocumentTitleTooLong), errors.Is(err, ErrDuplicateDocumentTitle),
+			errors.Is(err, ErrCopyTreeTooLarge):
 			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
 				Error:   "Bad Request",
 				Message: err.Error(),
@@ -1771,7 +1772,8 @@ func CopyFileHandler(c *fiber.Ctx) error {
 			errors.Is(err, ErrDuplicateFolderName),
 			errors.Is(err, ErrDocumentTitleRequired),
 			errors.Is(err, ErrDocumentTitleTooLong),
-			errors.Is(err, ErrDuplicateDocumentTitle):
+			errors.Is(err, ErrDuplicateDocumentTitle),
+			errors.Is(err, ErrCopyTreeTooLarge):
 			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{
 				Error:   "Validation Error",
 				Message: err.Error(),

--- a/packages/server/internal/workspace/service.go
+++ b/packages/server/internal/workspace/service.go
@@ -36,6 +36,7 @@ var ReservedFolderNames = []string{
 }
 
 var ErrDocumentQuotaExceeded = errors.New("已达到文档数量上限")
+var ErrCopyTreeTooLarge = errors.New("复制的文件夹层级过大")
 
 var folderHierarchyMu sync.Mutex
 
@@ -45,6 +46,8 @@ const (
 	PublicAccessPrivate           = "private"
 	PublicAccessAuthenticated     = "authenticated"
 	PublicAccessGlobal            = "public"
+	maxFolderCopyNodeCount        = 1000
+	maxFolderCopyDepth            = 32
 )
 
 func normalizePreferredImageTargetID(value string) string {
@@ -2360,6 +2363,9 @@ func CopyFile(userID uuid.UUID, fileID uuid.UUID, fileType string, destinationFo
 					return err
 				}
 			}
+			if err := ensureFolderCopyTreeWithinLimit(tx, userID, sourceFolder.ID); err != nil {
+				return err
+			}
 			copiedFolder, err := copyFolderTreeInTx(tx, userID, sourceFolder, destinationFolderID, name)
 			if err != nil {
 				return err
@@ -2374,6 +2380,39 @@ func CopyFile(userID uuid.UUID, fileID uuid.UUID, fileType string, destinationFo
 		return nil, err
 	}
 	return &copiedItem, nil
+}
+
+func ensureFolderCopyTreeWithinLimit(tx *gorm.DB, userID, rootFolderID uuid.UUID) error {
+	type queueItem struct {
+		folderID uuid.UUID
+		depth    int
+	}
+
+	queue := []queueItem{{folderID: rootFolderID, depth: 1}}
+	totalNodes := 0
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		totalNodes++
+		if totalNodes > maxFolderCopyNodeCount || current.depth > maxFolderCopyDepth {
+			return ErrCopyTreeTooLarge
+		}
+
+		var children []uuid.UUID
+		if err := tx.Model(&models.Folder{}).
+			Where("parent_id = ? AND owner_user_id = ? AND deleted_at IS NULL", current.folderID, userID).
+			Pluck("id", &children).Error; err != nil {
+			return err
+		}
+
+		for _, childID := range children {
+			queue = append(queue, queueItem{folderID: childID, depth: current.depth + 1})
+		}
+	}
+
+	return nil
 }
 
 func validateCopyDestination(tx *gorm.DB, userID uuid.UUID, destinationFolderID *uuid.UUID) error {


### PR DESCRIPTION
### Motivation
- The workspace `POST /api/v1/workspace/files/:id/copy` handler allowed recursive folder copies without limits, enabling an authenticated user to create large numbers of folder rows and hold the global `folderHierarchyMu` during long transactions.  
- Quota accounting only counted folder descriptions and document body bytes, so empty folders were effectively unmetered and could be amplified via repeated copies.

### Description
- Add a new sentinel error `ErrCopyTreeTooLarge` to represent oversized copy requests.  
- Introduce hard limits `maxFolderCopyNodeCount` and `maxFolderCopyDepth` and implement a preflight traversal `ensureFolderCopyTreeWithinLimit(...)` that BFS-traverses the source tree under the current DB transaction and returns `ErrCopyTreeTooLarge` if limits are exceeded.  
- Call `ensureFolderCopyTreeWithinLimit(...)` from the `CopyFile` folder branch before invoking the recursive `copyFolderTreeInTx` helper so oversized trees fail early.  
- Map `ErrCopyTreeTooLarge` to a validation-style client response in `CopyFileHandler` so the client receives a `400` instead of an internal error.  
- Apply formatting (`gofmt`) to the modified files.

### Testing
- Ran `gofmt -w packages/server/internal/workspace/service.go packages/server/internal/workspace/handler.go` successfully.  
- Ran `go test ./internal/workspace -run '^$' -count=1` from the `packages/server` module and it completed successfully (`ok` with no tests to run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a128350646c832b8353d9b2e5c6f2b3)