### PR TITLE
Move access token out of Svelte store

### DIFF
--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1,6 +1,5 @@
 import { auth } from '$lib/stores/auth';
 import { resolveApiUrl } from '$lib/config/api';
-import { get } from 'svelte/store';
 
 /**
  * A custom fetch wrapper that automatically adds the Authorization header
@@ -12,8 +11,8 @@ import { get } from 'svelte/store';
 export async function apiFetch(url: string, options: RequestInit = {}): Promise<Response> {
 	const resolvedUrl = resolveApiUrl(url);
 
-	// Get the current token from the store.
-	const token = get(auth).token;
+	// Get the current non-reactive access token.
+	const token = auth.getAccessToken();
 
 	// Set up the headers.
 	const headers = new Headers(options.headers);
@@ -32,7 +31,10 @@ export async function apiFetch(url: string, options: RequestInit = {}): Promise<
 	// across all concurrent callers and retry exactly once.
 	if (response.status === 401) {
 		try {
-			const newAccessToken = await auth.refreshToken();
+			const currentToken = auth.getAccessToken();
+			const newAccessToken = currentToken && currentToken !== token
+				? currentToken
+				: await auth.refreshToken();
 			if (newAccessToken) {
 				headers.set('Authorization', `Bearer ${newAccessToken}`);
 				options.headers = headers;

--- a/packages/web/src/lib/components/auth/RouteAuthGuard.svelte
+++ b/packages/web/src/lib/components/auth/RouteAuthGuard.svelte
@@ -14,16 +14,16 @@
 	// Show loading/placeholder when: required auth is loading or pending redirect to login,
 	// or guest mode has an authenticated user being redirected to workspace.
 	const showLoadingScreen = $derived(
-		(requiresAuth && ($auth.loading || !$auth.token)) ||
-			(requiresGuest && !$auth.loading && !!$auth.token)
+		(requiresAuth && ($auth.loading || !$auth.authenticated)) ||
+			(requiresGuest && !$auth.loading && $auth.authenticated)
 	);
 
 	$effect(() => {
 		if (!browser) return;
-		if (requiresAuth && !$auth.loading && !$auth.token) {
+		if (requiresAuth && !$auth.loading && !$auth.authenticated) {
 			goto('/login', { replaceState: true });
 		}
-		if (requiresGuest && !$auth.loading && $auth.token) {
+		if (requiresGuest && !$auth.loading && $auth.authenticated) {
 			goto('/workspace', { replaceState: true });
 		}
 	});

--- a/packages/web/src/lib/export/documentExportWorkflow.ts
+++ b/packages/web/src/lib/export/documentExportWorkflow.ts
@@ -1,4 +1,5 @@
 import type { JSONContent } from '@tiptap/core';
+import { apiFetch } from '$lib/api';
 import { pasteDocumentImage } from '$lib/api/editor';
 import { resolveApiUrl } from '$lib/config/api';
 import type { ExportAction } from '$lib/export/exportActions';
@@ -115,9 +116,7 @@ export async function prepareExportContentWithPublicImages(options: {
 				duration: Infinity
 			});
 
-			const response = await fetch(resolveApiUrl(`/api/v1/media/assets/${image.assetId}/content`), {
-				credentials: 'include'
-			});
+			const response = await apiFetch(`/api/v1/media/assets/${image.assetId}/content`);
 			if (!response.ok) {
 				throw new Error(`Failed to fetch private image ${image.assetId}`);
 			}

--- a/packages/web/src/lib/export/exportPrivateImages.ts
+++ b/packages/web/src/lib/export/exportPrivateImages.ts
@@ -1,4 +1,5 @@
 import type { JSONContent } from '@tiptap/core';
+import { apiFetch } from '$lib/api';
 import {
 	copyToClipboard,
 	downloadTextFile,
@@ -79,9 +80,7 @@ export async function inlineManagedImagesAsDataURLs(
 
 	const dataURLByAssetID = new Map<string, string>();
 	for (const item of managedImages) {
-		const response = await fetch(resolveAssetContentURL(item.assetId), {
-			credentials: 'include'
-		});
+		const response = await apiFetch(resolveAssetContentURL(item.assetId));
 		if (!response.ok) {
 			throw new Error(`Failed to fetch private image ${item.assetId}`);
 		}

--- a/packages/web/src/lib/stores/auth.ts
+++ b/packages/web/src/lib/stores/auth.ts
@@ -25,6 +25,7 @@ let accessToken: string | null = null;
 let refreshTimerId: NodeJS.Timeout | null = null;
 let refreshRetryTimerId: NodeJS.Timeout | null = null;
 let refreshPromise: Promise<string | null> | null = null;
+let authGeneration = 0;
 
 const REFRESH_RETRY_DELAY_MS = 30_000;
 const MIN_REFRESH_RETRY_DELAY_MS = 1_000;
@@ -144,6 +145,7 @@ function createAuthStore() {
 
 	async function performRefreshToken() {
 		console.log('Attempting to refresh token...');
+		const refreshGeneration = authGeneration;
 		try {
 			let newAccessToken: string;
 			try {
@@ -156,6 +158,9 @@ function createAuthStore() {
 				} else {
 					throw error;
 				}
+			}
+			if (refreshGeneration !== authGeneration) {
+				return null;
 			}
 
 			setAccessToken(newAccessToken);
@@ -277,6 +282,7 @@ function createAuthStore() {
 	}
 
 	async function logout() {
+		authGeneration += 1;
 		if (refreshTimerId) {
 			clearTimeout(refreshTimerId);
 			refreshTimerId = null;

--- a/packages/web/src/lib/stores/auth.ts
+++ b/packages/web/src/lib/stores/auth.ts
@@ -22,8 +22,8 @@ type AuthState = {
 // Keep the rotating access token outside the Svelte store. Token refresh should
 // not invalidate page effects; only real session/UI changes should notify subscribers.
 let accessToken: string | null = null;
-let refreshTimerId: NodeJS.Timeout | null = null;
-let refreshRetryTimerId: NodeJS.Timeout | null = null;
+let refreshTimerId: ReturnType<typeof setTimeout> | null = null;
+let refreshRetryTimerId: ReturnType<typeof setTimeout> | null = null;
 let refreshPromise: Promise<string | null> | null = null;
 let authGeneration = 0;
 

--- a/packages/web/src/lib/stores/auth.ts
+++ b/packages/web/src/lib/stores/auth.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { browser } from '$app/environment';
 import { resolveApiUrl } from '$lib/config/api';
 
@@ -160,6 +160,16 @@ function createAuthStore() {
 
 			setAccessToken(newAccessToken);
 			scheduleRefresh(newAccessToken);
+			const currentState = get({ subscribe });
+			if (currentState.loading || !currentState.authenticated || !currentState.user) {
+				try {
+					const user = await _fetchUser(newAccessToken);
+					set({ authenticated: true, user, loading: false });
+				} catch (profileError) {
+					console.error('Failed to refresh user profile after token refresh:', profileError);
+					update((state) => ({ ...state, authenticated: true, loading: false }));
+				}
+			}
 			console.log('Token refreshed successfully.');
 			return newAccessToken; // Return the new token on success
 		} catch (error) {

--- a/packages/web/src/lib/stores/auth.ts
+++ b/packages/web/src/lib/stores/auth.ts
@@ -1,4 +1,4 @@
-import { writable, get } from 'svelte/store';
+import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
 import { resolveApiUrl } from '$lib/config/api';
 
@@ -14,11 +14,14 @@ export type User = {
 };
 
 type AuthState = {
-	token: string | null;
+	authenticated: boolean;
 	user: User | null;
 	loading: boolean;
 };
 
+// Keep the rotating access token outside the Svelte store. Token refresh should
+// not invalidate page effects; only real session/UI changes should notify subscribers.
+let accessToken: string | null = null;
 let refreshTimerId: NodeJS.Timeout | null = null;
 let refreshRetryTimerId: NodeJS.Timeout | null = null;
 let refreshPromise: Promise<string | null> | null = null;
@@ -54,6 +57,10 @@ function getTokenExpiresAt(token: string): number | null {
 	return exp ? exp * 1000 : null;
 }
 
+function setAccessToken(token: string | null) {
+	accessToken = token;
+}
+
 function wait(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -73,7 +80,7 @@ async function withCrossTabRefreshLock<T>(callback: () => Promise<T>): Promise<T
 
 function createAuthStore() {
 	const { subscribe, set, update } = writable<AuthState>({
-		token: null,
+		authenticated: false,
 		user: null,
 		loading: true
 	});
@@ -151,7 +158,7 @@ function createAuthStore() {
 				}
 			}
 
-			update((state) => ({ ...state, token: newAccessToken }));
+			setAccessToken(newAccessToken);
 			scheduleRefresh(newAccessToken);
 			console.log('Token refreshed successfully.');
 			return newAccessToken; // Return the new token on success
@@ -161,7 +168,7 @@ function createAuthStore() {
 			if (refreshError.status === 401 || refreshError.status === 403) {
 				await logout();
 			} else {
-				const currentToken = get(auth).token;
+				const currentToken = accessToken;
 				if (currentToken) {
 					scheduleRefreshRetry(currentToken);
 				}
@@ -206,10 +213,11 @@ function createAuthStore() {
 
 		// Try to restore session from the backend using the refresh token cookie.
 		try {
-			const accessToken = await requestNewAccessToken();
-			const user = await _fetchUser(accessToken);
-			set({ token: accessToken, user, loading: false });
-			scheduleRefresh(accessToken);
+			const newAccessToken = await requestNewAccessToken();
+			const user = await _fetchUser(newAccessToken);
+			setAccessToken(newAccessToken);
+			set({ authenticated: true, user, loading: false });
+			scheduleRefresh(newAccessToken);
 			console.log('Session restored successfully.');
 			return;
 		} catch (error) {
@@ -230,7 +238,8 @@ function createAuthStore() {
 
 		try {
 			const user = await _fetchUser(token);
-			set({ token, user, loading: false });
+			setAccessToken(token);
+			set({ authenticated: true, user, loading: false });
 			scheduleRefresh(token); // Schedule the first refresh on successful login.
 		} catch (error) {
 			console.error('Failed to log in:', error);
@@ -239,7 +248,7 @@ function createAuthStore() {
 	}
 
 	async function refreshUser() {
-		const token = get(auth).token;
+		const token = accessToken;
 		if (!token) {
 			return null;
 		}
@@ -251,6 +260,10 @@ function createAuthStore() {
 
 	function setUser(user: User | null) {
 		update((state) => ({ ...state, user }));
+	}
+
+	function getAccessToken() {
+		return accessToken;
 	}
 
 	async function logout() {
@@ -275,7 +288,8 @@ function createAuthStore() {
 			console.error('Error during logout API call:', error);
 		} finally {
 			// Always clear the local state to log the user out on the frontend.
-			set({ token: null, user: null, loading: false });
+			setAccessToken(null);
+			set({ authenticated: false, user: null, loading: false });
 		}
 	}
 
@@ -285,6 +299,7 @@ function createAuthStore() {
 		loginAndFetchUser,
 		refreshUser,
 		setUser,
+		getAccessToken,
 		logout,
 		refreshToken // Expose the refresh function
 	};

--- a/packages/web/src/routes/admin/+layout.svelte
+++ b/packages/web/src/routes/admin/+layout.svelte
@@ -18,7 +18,7 @@
 
 	$effect(() => {
 		if (!browser) return;
-		if (!$auth.loading && $auth.token && !hasAdminAccess) {
+		if (!$auth.loading && $auth.authenticated && !hasAdminAccess) {
 			void goto('/user', { replaceState: true });
 		}
 	});
@@ -35,4 +35,3 @@
 		</div>
 	{/if}
 </RouteAuthGuard>
-

--- a/packages/web/src/routes/edit/documents/[id]/+page.svelte
+++ b/packages/web/src/routes/edit/documents/[id]/+page.svelte
@@ -84,6 +84,8 @@
 	let collaboration = $state<ProviderInstance | null>(null);
 	let collaborationDocumentId = $state<string | null>(null);
 	let documentLoadSequence = 0;
+	let loadingDocumentId: string | null = null;
+	let loadedDocumentId: string | null = null;
 	let collaborationError = $state<string | null>(null);
 	let collaborationIndicator = $state<
 		{ kind: 'single' | 'single-offline' | 'multi-pending' | 'multi'; label: string } | null
@@ -1408,8 +1410,13 @@
 	// Load document content when ID becomes available
 	$effect(() => {
 		if (documentId && !authSignal.loading && !realtimeConfigSignal.loading) {
+			if (loadingDocumentId === documentId || loadedDocumentId === documentId) {
+				return;
+			}
 			const targetDocumentId = documentId;
 			const loadSequence = ++documentLoadSequence;
+			loadingDocumentId = targetDocumentId;
+			loadedDocumentId = null;
 			isLoading = true;
 			settleCollaborationSaveWaiters(false);
 			resetOnlineMembers();
@@ -1482,6 +1489,7 @@
 					isSaving = false;
 					updateCollaborationIndicator();
 					console.log('[Load] Title loaded:', title);
+					loadedDocumentId = targetDocumentId;
 					isLoading = false;
 
 					if (collaborationEnabled) {
@@ -1532,6 +1540,9 @@
 					);
 					goto('/workspace');
 				} finally {
+					if (loadSequence === documentLoadSequence && loadingDocumentId === targetDocumentId) {
+						loadingDocumentId = null;
+					}
 					if (isCurrentLoad() && isLoading) {
 						isLoading = false;
 					}

--- a/packages/web/src/routes/edit/documents/[id]/+page.svelte
+++ b/packages/web/src/routes/edit/documents/[id]/+page.svelte
@@ -98,8 +98,6 @@
 	let presenceHeartbeatTimer: number | null = null;
 	let isInitializingCollaboration = $state(false);
 	let lastCollaborationAttemptAt = $state(0);
-	let loadedDocumentId: string | null = null;
-	let loadingDocumentId: string | null = null;
 	let isYjsConnected = $state(false);
 	let isLeaveConfirmOpen = $state(false);
 	let pendingNavigationUrl = $state<string | null>(null);
@@ -401,9 +399,7 @@
 					duration: Infinity
 				});
 
-				const response = await fetch(resolveApiUrl(`/api/v1/media/assets/${item.assetId}/content`), {
-					credentials: 'include'
-				});
+				const response = await apiFetch(`/api/v1/media/assets/${item.assetId}/content`);
 				if (!response.ok) {
 					throw new Error(`Failed to fetch private image ${item.assetId}`);
 				}
@@ -813,7 +809,7 @@
 	}
 
 	async function resolveRealtimeWsUrl(): Promise<string> {
-		if (!authSignal.token) {
+		if (!auth.getAccessToken()) {
 			throw new Error('Missing access token');
 		}
 
@@ -841,12 +837,7 @@
 			return 0;
 		}
 
-		const response = await fetch(buildRealtimePresenceURL(nextDocumentId), {
-			headers: {
-				Authorization: `Bearer ${authSignal.token}`
-			},
-			credentials: 'include'
-		});
+		const response = await apiFetch(buildRealtimePresenceURL(nextDocumentId));
 		if (!response.ok) {
 			throw new Error(`Failed to fetch collaboration presence: ${response.status}`);
 		}
@@ -866,7 +857,8 @@
 		nextDocumentId: string,
 		options: { keepalive?: boolean } = {}
 	): Promise<void> {
-		if (!collaborationEnabled || !browser || !nextDocumentId || !presenceSessionId || !authSignal.token) {
+		const token = auth.getAccessToken();
+		if (!collaborationEnabled || !browser || !nextDocumentId || !presenceSessionId || !token) {
 			return;
 		}
 
@@ -874,7 +866,7 @@
 			await fetch(buildRealtimePresenceURL(nextDocumentId), {
 				method: 'DELETE',
 				headers: {
-					Authorization: `Bearer ${authSignal.token}`,
+					Authorization: `Bearer ${token}`,
 					'X-Presence-Session-Id': presenceSessionId
 				},
 				credentials: 'include',
@@ -890,27 +882,24 @@
 			return;
 		}
 
-		if (!authSignal.token) {
+		if (!auth.getAccessToken()) {
 			return;
 		}
 
 		hasAttemptedPresence = true;
 		const sessionId = ensurePresenceSessionId();
 		const heartbeat = async () => {
-			const token = authSignal.token;
-			if (!token) {
+			if (!auth.getAccessToken()) {
 				return;
 			}
 
 			try {
-				const response = await fetch(buildRealtimePresenceURL(nextDocumentId), {
+				const response = await apiFetch(buildRealtimePresenceURL(nextDocumentId), {
 					method: 'PUT',
 					headers: {
-						Authorization: `Bearer ${token}`,
 						'Content-Type': 'application/json',
 						'X-Presence-Session-Id': sessionId
 					},
-					credentials: 'include',
 					body: JSON.stringify({ sessionId })
 				});
 				if (response.status === 429) {
@@ -958,7 +947,7 @@
 		}
 
 		const wsUrl = await resolveRealtimeWsUrl();
-		const token = authSignal.token;
+		const token = auth.getAccessToken();
 		if (!token) {
 			throw new Error('Missing access token');
 		}
@@ -1420,11 +1409,7 @@
 	$effect(() => {
 		if (documentId && !authSignal.loading && !realtimeConfigSignal.loading) {
 			const targetDocumentId = documentId;
-			if (loadedDocumentId === targetDocumentId || loadingDocumentId === targetDocumentId) {
-				return;
-			}
 			const loadSequence = ++documentLoadSequence;
-			loadingDocumentId = targetDocumentId;
 			isLoading = true;
 			settleCollaborationSaveWaiters(false);
 			resetOnlineMembers();
@@ -1497,7 +1482,6 @@
 					isSaving = false;
 					updateCollaborationIndicator();
 					console.log('[Load] Title loaded:', title);
-					loadedDocumentId = targetDocumentId;
 					isLoading = false;
 
 					if (collaborationEnabled) {
@@ -1535,7 +1519,6 @@
 						return;
 					}
 					console.error('[Load] Failed to load document:', error);
-					loadedDocumentId = null;
 					collaboration = null;
 					collaborationDocumentId = null;
 					collaborationIndicator = null;
@@ -1549,9 +1532,6 @@
 					);
 					goto('/workspace');
 				} finally {
-					if (loadingDocumentId === targetDocumentId) {
-						loadingDocumentId = null;
-					}
 					if (isCurrentLoad() && isLoading) {
 						isLoading = false;
 					}

--- a/packages/web/src/routes/edit/documents/[id]/+page.svelte
+++ b/packages/web/src/routes/edit/documents/[id]/+page.svelte
@@ -84,8 +84,6 @@
 	let collaboration = $state<ProviderInstance | null>(null);
 	let collaborationDocumentId = $state<string | null>(null);
 	let documentLoadSequence = 0;
-	let loadingDocumentId: string | null = null;
-	let loadedDocumentId: string | null = null;
 	let collaborationError = $state<string | null>(null);
 	let collaborationIndicator = $state<
 		{ kind: 'single' | 'single-offline' | 'multi-pending' | 'multi'; label: string } | null
@@ -859,19 +857,16 @@
 		nextDocumentId: string,
 		options: { keepalive?: boolean } = {}
 	): Promise<void> {
-		const token = auth.getAccessToken();
-		if (!collaborationEnabled || !browser || !nextDocumentId || !presenceSessionId || !token) {
+		if (!collaborationEnabled || !browser || !nextDocumentId || !presenceSessionId) {
 			return;
 		}
 
 		try {
-			await fetch(buildRealtimePresenceURL(nextDocumentId), {
+			await apiFetch(buildRealtimePresenceURL(nextDocumentId), {
 				method: 'DELETE',
 				headers: {
-					Authorization: `Bearer ${token}`,
 					'X-Presence-Session-Id': presenceSessionId
 				},
-				credentials: 'include',
 				keepalive: options.keepalive ?? false
 			});
 		} catch (error) {
@@ -1410,13 +1405,8 @@
 	// Load document content when ID becomes available
 	$effect(() => {
 		if (documentId && !authSignal.loading && !realtimeConfigSignal.loading) {
-			if (loadingDocumentId === documentId || loadedDocumentId === documentId) {
-				return;
-			}
 			const targetDocumentId = documentId;
 			const loadSequence = ++documentLoadSequence;
-			loadingDocumentId = targetDocumentId;
-			loadedDocumentId = null;
 			isLoading = true;
 			settleCollaborationSaveWaiters(false);
 			resetOnlineMembers();
@@ -1489,7 +1479,6 @@
 					isSaving = false;
 					updateCollaborationIndicator();
 					console.log('[Load] Title loaded:', title);
-					loadedDocumentId = targetDocumentId;
 					isLoading = false;
 
 					if (collaborationEnabled) {
@@ -1540,9 +1529,6 @@
 					);
 					goto('/workspace');
 				} finally {
-					if (loadSequence === documentLoadSequence && loadingDocumentId === targetDocumentId) {
-						loadingDocumentId = null;
-					}
 					if (isCurrentLoad() && isLoading) {
 						isLoading = false;
 					}


### PR DESCRIPTION
Expose getAccessToken and keep the rotating token off the Svelte store. Replace the token field with an authenticated boolean and update guards to
use authenticated. Switch private media and realtime fetches to apiFetch so
Authorization is applied consistently. Remove
loadedDocumentId/loadingDocumentId