### PR TITLE
fix: 修复 MCP 段落编辑标题重复与 Token 过期报错不明确

### DIFF
--- a/packages/server/internal/ai/markdown_test.go
+++ b/packages/server/internal/ai/markdown_test.go
@@ -85,3 +85,40 @@ func TestApplyMarkdownPatchReplaceSection(t *testing.T) {
 		t.Fatalf("section content was not replaced:\n%s", output)
 	}
 }
+
+func TestApplyMarkdownPatchReplaceSectionStripsEchoedHeading(t *testing.T) {
+	input := "## 背景\n\n旧内容\n\n## 其他\n\n保留"
+	output, err := applyMarkdownPatch(input, []PatchOperation{{
+		Type:    "replace",
+		Target:  "section",
+		Heading: "背景",
+		Content: "## 背景\n\n新内容",
+	}})
+	if err != nil {
+		t.Fatalf("applyMarkdownPatch returned error: %v", err)
+	}
+	if got := strings.Count(output, "## 背景"); got != 1 {
+		t.Fatalf("heading should appear exactly once, got %d:\n%s", got, output)
+	}
+	if !strings.Contains(output, "新内容") || strings.Contains(output, "旧内容") {
+		t.Fatalf("section body was not replaced:\n%s", output)
+	}
+}
+
+func TestApplyMarkdownPatchPrependSectionStripsEchoedHeading(t *testing.T) {
+	input := "## 背景\n\n原有内容"
+	output, err := applyMarkdownPatch(input, []PatchOperation{{
+		Type:    "prepend",
+		Heading: "背景",
+		Content: "## 背景\n\n置顶说明",
+	}})
+	if err != nil {
+		t.Fatalf("applyMarkdownPatch returned error: %v", err)
+	}
+	if got := strings.Count(output, "## 背景"); got != 1 {
+		t.Fatalf("heading should appear exactly once, got %d:\n%s", got, output)
+	}
+	if !strings.Contains(output, "置顶说明") || !strings.Contains(output, "原有内容") {
+		t.Fatalf("prepend content missing:\n%s", output)
+	}
+}

--- a/packages/server/internal/ai/patch.go
+++ b/packages/server/internal/ai/patch.go
@@ -118,11 +118,38 @@ func findSection(markdown string, heading string) (markdownSection, bool) {
 	return markdownSection{}, false
 }
 
+// stripRedundantHeading drops a leading Markdown heading line from content when
+// it merely repeats the heading the operation already targets. Section-scoped
+// operations keep the existing heading and only rewrite the body, so a client
+// that echoes the whole section back (heading included) would otherwise leave
+// the heading duplicated in the document.
+func stripRedundantHeading(content string, heading string) string {
+	heading = strings.TrimSpace(heading)
+	if heading == "" {
+		return content
+	}
+	trimmed := strings.TrimLeft(content, "\n")
+	firstLine := trimmed
+	if idx := strings.IndexByte(trimmed, '\n'); idx >= 0 {
+		firstLine = trimmed[:idx]
+	}
+	match := markdownHeadingPattern.FindStringSubmatch(firstLine)
+	if match == nil || strings.TrimSpace(match[2]) != heading {
+		return content
+	}
+	idx := strings.IndexByte(trimmed, '\n')
+	if idx < 0 {
+		return ""
+	}
+	return strings.TrimLeft(trimmed[idx+1:], "\n")
+}
+
 func replaceSection(markdown string, heading string, content string) (string, error) {
 	section, ok := findSection(markdown, heading)
 	if !ok {
 		return "", fmt.Errorf("heading not found")
 	}
+	content = stripRedundantHeading(content, heading)
 	return markdown[:section.contentStart] + strings.Trim(content, "\n") + "\n\n" + markdown[section.end:], nil
 }
 
@@ -132,6 +159,7 @@ func insertInSection(markdown string, heading string, content string, atStart bo
 		return "", fmt.Errorf("heading not found")
 	}
 	if atStart {
+		content = stripRedundantHeading(content, heading)
 		return markdown[:section.contentStart] + content + markdown[section.contentStart:], nil
 	}
 	return markdown[:section.end] + content + markdown[section.end:], nil

--- a/packages/server/internal/apitoken/auth_error_test.go
+++ b/packages/server/internal/apitoken/auth_error_test.go
@@ -1,0 +1,132 @@
+package apitoken
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"g.co1d.in/Coldin04/Cyime/server/internal/models"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+func TestAuthenticateExpiredTokenReturnsExpiredError(t *testing.T) {
+	db := setupAPITokenTestDB(t)
+	userID := uuid.New()
+	if err := db.Create(&models.User{ID: userID}).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	created, err := CreateToken(userID, CreateTokenInput{
+		Name:   "expiring",
+		Scopes: []string{ScopeWorkspaceRead},
+	})
+	if err != nil {
+		t.Fatalf("CreateToken returned error: %v", err)
+	}
+
+	past := time.Now().Add(-time.Hour)
+	if err := db.Model(&models.ApiToken{}).Where("id = ?", created.ID).Update("expires_at", past).Error; err != nil {
+		t.Fatalf("expire token: %v", err)
+	}
+
+	if _, err := Authenticate(created.Token, "127.0.0.1"); !errors.Is(err, ErrTokenExpired) {
+		t.Fatalf("expired token error = %v, want ErrTokenExpired", err)
+	}
+}
+
+func TestAuthErrorCode(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCode string
+	}{
+		{"expired", ErrTokenExpired, "token_expired"},
+		{"revoked", ErrTokenRevoked, "token_revoked"},
+		{"unknown", ErrTokenUnauthorized, "invalid_token"},
+		{"missing header", fiber.NewError(fiber.StatusUnauthorized, "missing Authorization header"), "invalid_token"},
+	}
+	for _, tc := range cases {
+		code, _ := authErrorCode(tc.err)
+		if code != tc.wantCode {
+			t.Fatalf("%s: code = %q, want %q", tc.name, code, tc.wantCode)
+		}
+	}
+
+	// Unknown/invalid tokens must stay generic so a caller cannot probe whether
+	// a given token value exists.
+	if _, description := authErrorCode(ErrTokenUnauthorized); description != ErrTokenUnauthorized.Error() {
+		t.Fatalf("invalid token description = %q, want generic %q", description, ErrTokenUnauthorized.Error())
+	}
+}
+
+func TestProtectedDistinguishesExpiredFromInvalidToken(t *testing.T) {
+	db := setupAPITokenTestDB(t)
+	userID := uuid.New()
+	if err := db.Create(&models.User{ID: userID}).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	created, err := CreateToken(userID, CreateTokenInput{
+		Name:   "expiring",
+		Scopes: []string{ScopeWorkspaceRead},
+	})
+	if err != nil {
+		t.Fatalf("CreateToken returned error: %v", err)
+	}
+	past := time.Now().Add(-time.Hour)
+	if err := db.Model(&models.ApiToken{}).Where("id = ?", created.ID).Update("expires_at", past).Error; err != nil {
+		t.Fatalf("expire token: %v", err)
+	}
+
+	app := fiber.New()
+	app.Get("/x", Protected(ScopeWorkspaceRead), func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	// Expired token: the caller should learn to refresh, not replace, the token.
+	expiredCode, expiredHeader, expiredStatus := doProtectedRequest(t, app, "Bearer "+created.Token)
+	if expiredStatus != fiber.StatusUnauthorized {
+		t.Fatalf("expired status = %d, want 401", expiredStatus)
+	}
+	if expiredCode != "token_expired" {
+		t.Fatalf("expired code = %q, want token_expired", expiredCode)
+	}
+	if !strings.Contains(expiredHeader, "token_expired") {
+		t.Fatalf("expired WWW-Authenticate = %q, want to mention token_expired", expiredHeader)
+	}
+
+	// Unknown token: response must stay generic so token existence is not leaked.
+	unknownCode, _, unknownStatus := doProtectedRequest(t, app, "Bearer cyime_sk_does_not_exist")
+	if unknownStatus != fiber.StatusUnauthorized {
+		t.Fatalf("unknown status = %d, want 401", unknownStatus)
+	}
+	if unknownCode != "invalid_token" {
+		t.Fatalf("unknown code = %q, want invalid_token", unknownCode)
+	}
+}
+
+func doProtectedRequest(t *testing.T, app *fiber.App, authorization string) (code string, wwwAuthenticate string, status int) {
+	t.Helper()
+	req := httptest.NewRequest(fiber.MethodGet, "/x", nil)
+	req.Header.Set(fiber.HeaderAuthorization, authorization)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var payload struct {
+		Code string `json:"code"`
+	}
+	_ = json.Unmarshal(body, &payload)
+	return payload.Code, resp.Header.Get(fiber.HeaderWWWAuthenticate), resp.StatusCode
+}

--- a/packages/server/internal/apitoken/middleware.go
+++ b/packages/server/internal/apitoken/middleware.go
@@ -1,6 +1,8 @@
 package apitoken
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
@@ -15,12 +17,12 @@ func Protected(requiredScopes ...string) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		rawToken, err := bearerToken(c)
 		if err != nil {
-			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": err.Error()})
+			return writeAuthError(c, err)
 		}
 
 		authenticated, err := Authenticate(rawToken, c.IP())
 		if err != nil {
-			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": err.Error()})
+			return writeAuthError(c, err)
 		}
 		if !HasScopes(authenticated.Scopes, requiredScopes...) {
 			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
@@ -47,4 +49,35 @@ func bearerToken(c *fiber.Ctx) (string, error) {
 		return "", fiber.NewError(fiber.StatusUnauthorized, "malformed Authorization header")
 	}
 	return strings.TrimSpace(parts[1]), nil
+}
+
+// authErrorCode maps an authentication failure to a stable, machine-readable
+// code and human-readable description. Expired and revoked tokens are reported
+// distinctly so a client knows to refresh or replace the token, while unknown or
+// malformed credentials stay deliberately generic so a caller cannot probe
+// whether a given token value exists.
+func authErrorCode(err error) (code string, description string) {
+	switch {
+	case errors.Is(err, ErrTokenExpired):
+		return "token_expired", ErrTokenExpired.Error()
+	case errors.Is(err, ErrTokenRevoked):
+		return "token_revoked", ErrTokenRevoked.Error()
+	default:
+		var fiberErr *fiber.Error
+		if errors.As(err, &fiberErr) {
+			return "invalid_token", fiberErr.Message
+		}
+		return "invalid_token", ErrTokenUnauthorized.Error()
+	}
+}
+
+// writeAuthError renders a 401 with a machine-readable code plus an RFC 6750
+// WWW-Authenticate challenge so Bearer clients can react to expiry automatically.
+func writeAuthError(c *fiber.Ctx, err error) error {
+	code, description := authErrorCode(err)
+	c.Set(fiber.HeaderWWWAuthenticate, fmt.Sprintf("Bearer error=%q, error_description=%q", code, description))
+	return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+		"error": description,
+		"code":  code,
+	})
 }

--- a/packages/server/internal/apitoken/service.go
+++ b/packages/server/internal/apitoken/service.go
@@ -23,6 +23,7 @@ var (
 	ErrTokenNameTooLong  = errors.New("token name is too long")
 	ErrInvalidExpiry     = errors.New("token expiry must be in the future")
 	ErrTokenUnauthorized = errors.New("invalid or expired API token")
+	ErrTokenExpired      = errors.New("the API token has expired")
 	ErrTokenRevoked      = errors.New("API token has been revoked")
 )
 
@@ -214,7 +215,7 @@ func Authenticate(rawToken string, ip string) (*AuthenticatedToken, error) {
 		return nil, ErrTokenRevoked
 	}
 	if row.ExpiresAt != nil && !row.ExpiresAt.After(now) {
-		return nil, ErrTokenUnauthorized
+		return nil, ErrTokenExpired
 	}
 
 	scopes, err := DecodeScopes(row.Scopes)

--- a/packages/server/internal/mcp/handler.go
+++ b/packages/server/internal/mcp/handler.go
@@ -261,9 +261,9 @@ var tools = []toolDefinition{
 			"operations": objectArraySchema("Patch operations.", map[string]any{
 				"type":    enumSchema("Patch operation.", []string{"append", "prepend", "replace", "insert_after", "insert_before"}),
 				"target":  stringSchema("Optional target, for example section."),
-				"heading": stringSchema("Optional Markdown heading."),
+				"heading": stringSchema("Optional Markdown heading used to locate a section. append/prepend/replace keep this heading in place, so it stays in the document."),
 				"match":   stringSchema("Optional exact text match."),
-				"content": stringSchema("Markdown fragment."),
+				"content": stringSchema("Markdown fragment. When targeting a section via heading, provide body content only and do not repeat the heading line, otherwise the heading is duplicated."),
 			}, []string{"type", "content"}),
 		}, []string{"id", "format", "operations"}),
 		Call: callPatchMarkdownDocument,


### PR DESCRIPTION
MCP 按标题增量编辑时，内容中回传的同名标题会被自动剥离，并在工具描述中说明该契约。API Token 过期现返回独立的 token_expired 错误码与 WWW-Authenticate 头，未知 Token 仍保持笼统响应以防枚举。